### PR TITLE
Gabrielcostadev/ver histograma

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,15 @@ class JanelaPrincipal(QMainWindow):
         acao_sair.triggered.connect(self.close)
 
         # --- Menu Pixels (operações pontuais) ---
+        menu_analise = barra.addMenu("Analise")
+        diretorio_pixels = os.path.join(_DIRETORIO_RAIZ, "plugins", "analise")
+        carregar_plugins_dinamicamente(menu_analise, diretorio_pixels, self)
+
+        if not menu_analise.actions():
+            aviso = menu_analise.addAction("(nenhum plugin encontrado)")
+            aviso.setEnabled(False)
+            
+        # --- Menu Pixels (operações pontuais) ---
         menu_pixels = barra.addMenu("Pixels")
         diretorio_pixels = os.path.join(_DIRETORIO_RAIZ, "plugins", "pixels")
         carregar_plugins_dinamicamente(menu_pixels, diretorio_pixels, self)

--- a/plugins/analise/histograma.py
+++ b/plugins/analise/histograma.py
@@ -1,0 +1,162 @@
+import numpy as np
+import cv2
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QVBoxLayout,
+    QLabel,
+    QComboBox,
+    QPushButton,
+)
+
+from core.plugin_base import PluginBase
+
+
+class HistogramaPlugin(PluginBase):
+    display_name = "Histograma da Imagem"
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        self._btn_atualizar = QPushButton("Atualizar Histograma")
+
+        self._label_hist = QLabel("Histograma aqui")
+        self._label_hist.setAlignment(Qt.AlignCenter)
+        self._label_hist.setMinimumHeight(200)
+        self._canal_ativo = "RGB"
+
+        self._canal_combo = QComboBox()
+        self._canal_combo.addItems(["RGB", "R (Vermelho)", "G (Verde)", "B (Azul)", "Cinza", "Alfa"])
+        self._canal_combo.currentTextChanged.connect(self._atualizar_canal)
+
+        layout.addWidget(self._btn_atualizar)
+        layout.addWidget(self._canal_combo)
+        layout.addWidget(self._label_hist)
+
+        self._btn_atualizar.clicked.connect(self._gerar_histograma)
+
+        self.setLayout(layout)
+        self.setMinimumWidth(400)
+
+        # Gera automaticamente ao abrir
+        self._gerar_histograma()
+
+    # --------------------------------------------------
+    # Núcleo do histograma
+    # --------------------------------------------------
+
+    def _gerar_histograma(self):
+        imagem = self.imagem_original
+
+        # --- Modo cinza tem prioridade ---
+        if self._canal_ativo == "Cinza":
+            imagem = cv2.cvtColor(imagem, cv2.COLOR_RGB2GRAY)
+            hist = cv2.calcHist([imagem], [0], None, [256], [0, 256]).flatten()
+
+            img_hist = self._desenhar_histograma(
+                [hist],
+                cores=[(255, 255, 255)]
+            )
+
+        else:
+            canais = {
+                "B (Azul)": (0, (255, 0, 0)),
+                "G (Verde)": (1, (0, 255, 0)),
+                "R (Vermelho)": (2, (0, 0, 255)),
+            }
+
+            if self._canal_ativo == "RGB":
+                hists = []
+                cores = []
+                for nome, (idx, cor) in canais.items():
+                    hist = cv2.calcHist([imagem], [idx], None, [256], [0, 256]).flatten()
+                    hists.append(hist)
+                    cores.append(cor)
+
+            elif self._canal_ativo in canais:
+                idx, cor = canais[self._canal_ativo]
+                hist = cv2.calcHist([imagem], [idx], None, [256], [0, 256]).flatten()
+                hists = [hist]
+                cores = [cor]
+
+            else:
+                return  # fallback seguro
+
+            img_hist = self._desenhar_histograma(hists, cores)
+
+        self._exibir_histograma(img_hist)
+
+    # --------------------------------------------------
+    # Renderização manual
+    # --------------------------------------------------
+
+    def _desenhar_histograma(self, hists, cores):
+        altura = 300
+        largura = 512
+
+        # Canvas base (preto)
+        base = np.zeros((altura, largura, 3), dtype=np.uint8)
+
+        x = np.arange(256) * 2  # escala horizontal
+
+        for hist, cor in zip(hists, cores):
+            hist = hist.copy()
+            cv2.normalize(hist, hist, 0, altura, cv2.NORM_MINMAX)
+            hist = hist.flatten().astype(int)
+
+            # 🔷 Criar polígono fechado
+            pts = np.column_stack((x, altura - hist))
+
+            # adicionar base (fechamento do polígono)
+            pts = np.vstack([
+                pts,
+                [x[-1], altura],
+                [x[0], altura]
+            ])
+
+            pts = pts.astype(np.int32).reshape((-1, 1, 2))
+
+            # 🔷 Camada temporária
+            overlay = np.zeros_like(base)
+
+            # Preencher área
+            cv2.fillPoly(overlay, [pts], cor)
+
+            # 🔷 Alpha blending (transparência)
+            alpha = 0.4
+            base = cv2.addWeighted(base, 1.0, overlay, alpha, 0)
+
+        return base
+
+    # --------------------------------------------------
+    # Exibir no QLabel
+    # --------------------------------------------------
+
+    def _exibir_histograma(self, imagem_bgr):
+        imagem_rgb = cv2.cvtColor(imagem_bgr, cv2.COLOR_BGR2RGB)
+
+        h, w, ch = imagem_rgb.shape
+        bytes_per_line = ch * w
+
+        qimg = QImage(
+            imagem_rgb.data,
+            w,
+            h,
+            bytes_per_line,
+            QImage.Format_RGB888
+        )
+
+        pixmap = QPixmap.fromImage(qimg)
+        self._label_hist.setPixmap(pixmap)
+        
+    def _atualizar_canal(self, texto):
+        self._canal_ativo = texto
+        self._gerar_histograma()
+
+    # --------------------------------------------------
+    # Override (não altera imagem)
+    # --------------------------------------------------
+
+    def processar(self, imagem: np.ndarray) -> np.ndarray:
+        return imagem

--- a/plugins/analise/histograma.py
+++ b/plugins/analise/histograma.py
@@ -24,10 +24,14 @@ class HistogramaPlugin(PluginBase):
         self._label_hist = QLabel("Histograma aqui")
         self._label_hist.setAlignment(Qt.AlignCenter)
         self._label_hist.setMinimumHeight(200)
+
         self._canal_ativo = "RGB"
 
         self._canal_combo = QComboBox()
-        self._canal_combo.addItems(["RGB", "R (Vermelho)", "G (Verde)", "B (Azul)", "Cinza", "Alfa"])
+        self._canal_combo.addItems([
+            "RGB", "R (Vermelho)", "G (Verde)",
+            "B (Azul)", "Cinza", "Alfa"
+        ])
         self._canal_combo.currentTextChanged.connect(self._atualizar_canal)
 
         layout.addWidget(self._btn_atualizar)
@@ -39,76 +43,110 @@ class HistogramaPlugin(PluginBase):
         self.setLayout(layout)
         self.setMinimumWidth(400)
 
-        # Gera automaticamente ao abrir
+        # 🔷 Cache de histogramas
+        self._hist_cache = {}
+
         self._gerar_histograma()
 
-    # --------------------------------------------------
-    # Núcleo do histograma
-    # --------------------------------------------------
+    # ==================================================
+    # 🔥 API PÚBLICA (REUTILIZAÇÃO EM OUTROS PLUGINS)
+    # ==================================================
+    def get_histograma(self, canal=None):
+        """
+        Retorna histograma (ou lista de histogramas) já cacheado.
+        Pode ser usado por outros plugins.
+        """
+        canal = canal or self._canal_ativo
+        return self._obter_histograma(self.imagem_original, canal)
 
+    # ==================================================
+    # 🔥 CACHE
+    # ==================================================
+    def _obter_histograma(self, imagem, canal):
+        chave = (id(imagem), canal)
+
+        if chave in self._hist_cache:
+            return self._hist_cache[chave]
+
+        hists = self._calcular_histograma(imagem, canal)
+        self._hist_cache[chave] = hists
+
+        return hists
+
+    def limpar_cache(self):
+        """Use quando a imagem mudar"""
+        self._hist_cache.clear()
+
+    # ==================================================
+    # 🔥 CÁLCULO PURO
+    # ==================================================
+    def _calcular_histograma(self, imagem, canal):
+        if canal == "Cinza":
+            img = cv2.cvtColor(imagem, cv2.COLOR_RGB2GRAY)
+            hist = cv2.calcHist([img], [0], None, [256], [0, 256]).flatten()
+            return [hist]
+
+        canais = {
+            "B (Azul)": (0, (255, 0, 0)),
+            "G (Verde)": (1, (0, 255, 0)),
+            "R (Vermelho)": (2, (0, 0, 255)),
+        }
+
+        if canal == "RGB":
+            hists = []
+            for idx, _ in canais.values():
+                hist = cv2.calcHist([imagem], [idx], None, [256], [0, 256]).flatten()
+                hists.append(hist)
+            return hists
+
+        elif canal in canais:
+            idx, _ = canais[canal]
+            hist = cv2.calcHist([imagem], [idx], None, [256], [0, 256]).flatten()
+            return [hist]
+
+        return []
+
+    # ==================================================
+    # 🔥 PIPELINE PRINCIPAL
+    # ==================================================
     def _gerar_histograma(self):
         imagem = self.imagem_original
 
-        # --- Modo cinza tem prioridade ---
-        if self._canal_ativo == "Cinza":
-            imagem = cv2.cvtColor(imagem, cv2.COLOR_RGB2GRAY)
-            hist = cv2.calcHist([imagem], [0], None, [256], [0, 256]).flatten()
+        hists = self._obter_histograma(imagem, self._canal_ativo)
+        cores = self._obter_cores(self._canal_ativo)
 
-            img_hist = self._desenhar_histograma(
-                [hist],
-                cores=[(255, 255, 255)]
-            )
-
-        else:
-            canais = {
-                "B (Azul)": (0, (255, 0, 0)),
-                "G (Verde)": (1, (0, 255, 0)),
-                "R (Vermelho)": (2, (0, 0, 255)),
-            }
-
-            if self._canal_ativo == "RGB":
-                hists = []
-                cores = []
-                for nome, (idx, cor) in canais.items():
-                    hist = cv2.calcHist([imagem], [idx], None, [256], [0, 256]).flatten()
-                    hists.append(hist)
-                    cores.append(cor)
-
-            elif self._canal_ativo in canais:
-                idx, cor = canais[self._canal_ativo]
-                hist = cv2.calcHist([imagem], [idx], None, [256], [0, 256]).flatten()
-                hists = [hist]
-                cores = [cor]
-
-            else:
-                return  # fallback seguro
-
-            img_hist = self._desenhar_histograma(hists, cores)
-
+        img_hist = self._renderizar_histograma(hists, cores)
         self._exibir_histograma(img_hist)
 
-    # --------------------------------------------------
-    # Renderização manual
-    # --------------------------------------------------
+    # ==================================================
+    # 🔥 CORES
+    # ==================================================
+    def _obter_cores(self, canal):
+        mapa = {
+            "RGB": [(255, 0, 0), (0, 255, 0), (0, 0, 255)],
+            "R (Vermelho)": [(0, 0, 255)],
+            "G (Verde)": [(0, 255, 0)],
+            "B (Azul)": [(255, 0, 0)],
+            "Cinza": [(255, 255, 255)],
+        }
+        return mapa.get(canal, [(255, 255, 255)])
 
-    def _desenhar_histograma(self, hists, cores):
+    # ==================================================
+    # 🔥 RENDERIZAÇÃO
+    # ==================================================
+    def _renderizar_histograma(self, hists, cores):
         altura = 300
         largura = 512
 
-        # Canvas base (preto)
         base = np.zeros((altura, largura, 3), dtype=np.uint8)
-
-        x = np.arange(256) * 2  # escala horizontal
+        x = np.arange(256) * 2
 
         for hist, cor in zip(hists, cores):
             hist = hist.copy()
             cv2.normalize(hist, hist, 0, altura, cv2.NORM_MINMAX)
             hist = hist.flatten().astype(int)
 
-            # 🔷 Criar polígono fechado
             pts = np.column_stack((x, altura - hist))
-
-            # adicionar base (fechamento do polígono)
             pts = np.vstack([
                 pts,
                 [x[-1], altura],
@@ -117,22 +155,16 @@ class HistogramaPlugin(PluginBase):
 
             pts = pts.astype(np.int32).reshape((-1, 1, 2))
 
-            # 🔷 Camada temporária
             overlay = np.zeros_like(base)
-
-            # Preencher área
             cv2.fillPoly(overlay, [pts], cor)
 
-            # 🔷 Alpha blending (transparência)
-            alpha = 0.4
-            base = cv2.addWeighted(base, 1.0, overlay, alpha, 0)
+            base = cv2.addWeighted(base, 1.0, overlay, 0.4, 0)
 
         return base
 
-    # --------------------------------------------------
-    # Exibir no QLabel
-    # --------------------------------------------------
-
+    # ==================================================
+    # 🔥 EXIBIÇÃO
+    # ==================================================
     def _exibir_histograma(self, imagem_bgr):
         imagem_rgb = cv2.cvtColor(imagem_bgr, cv2.COLOR_BGR2RGB)
 
@@ -149,14 +181,11 @@ class HistogramaPlugin(PluginBase):
 
         pixmap = QPixmap.fromImage(qimg)
         self._label_hist.setPixmap(pixmap)
-        
+
     def _atualizar_canal(self, texto):
         self._canal_ativo = texto
         self._gerar_histograma()
 
-    # --------------------------------------------------
-    # Override (não altera imagem)
-    # --------------------------------------------------
-
+    # ==================================================
     def processar(self, imagem: np.ndarray) -> np.ndarray:
         return imagem


### PR DESCRIPTION
@gustavoresque eu mencionei anteriormente que poderia ter um menu "Análise" para conter plugin de obtenção de informação da image.
Gostaria de reforçar novamente essa separação e pontuar que a [minha issue](https://github.com/Disciplinas-gustavoresque-UFPA/Processamento-de-Imagens-2026v2/issues/20#issuecomment-4192762826) que falava em aplicar a funcionalidade de equalização de histograma nesse plugin poderia ser revista, me parece mais interessante separar essa funcionalidade em outro plugin, pois ele faria uma alteração na imagem.

O classe do plugin de visualização de histograma pode conter um atributo do próprio histograma pra ser utilziado por outros plugins que precisam desse dado, no caso o de equalização.

O @antenoraires essa funcionalidade tb, já poderia ser dessa maneira

Atualmente o plugin de visualização de histograma estar assim:

<img width="667" height="517" alt="image" src="https://github.com/user-attachments/assets/db370457-34d4-463c-9ecf-0b95e56defc8" />


Com suporte para analisar os diferentes canais:

<img width="668" height="512" alt="image" src="https://github.com/user-attachments/assets/1a500369-70eb-4941-a674-3cb8499beb9b" />


Falta adicionar:

- Dados estatisticos, conforme o GIMP
- Agrupamente de faixa de pixel
- Alteração entre eixos X e Y
- Seleção de faixa especificar de intensidades de cor para análise (igual o GIMP)