### PR TITLE
fix(placar): persiste historico e acumula badges (closes #56)

### DIFF
--- a/.github/scripts/gerar_placar.py
+++ b/.github/scripts/gerar_placar.py
@@ -11,7 +11,10 @@ REPO_NAME = os.getenv('GITHUB_REPOSITORY').split('/')[1]
 PROFESSOR_USER = "gustavoresque"
 
 # Lista de usuários que NÃO devem aparecer no placar ou nas métricas
-IGNORE_USERS = ["gustavoresque", "copilot", "github-actions[bot]"]
+IGNORE_USERS = {"gustavoresque", "copilot", "github-actions[bot]"}
+
+def deve_ignorar(login):
+    return login.lower() in IGNORE_USERS
 
 BASE_URL = "https://api.github.com"
 HEADERS = {
@@ -71,7 +74,7 @@ def processar_dados(atividades, uma_semana_atras):
         eh_pr = 'pull_request' in item
         
         # 1. Conta criação de Issue ou PR (apenas se foi criado nos últimos 7 dias)
-        if item['created_at'] >= uma_semana_atras and autor_item not in IGNORE_USERS:
+        if item['created_at'] >= uma_semana_atras and not deve_ignorar(autor_item):
             if eh_pr:
                 engajamento[autor_item]["prs"] += 1
             else:
@@ -84,7 +87,7 @@ def processar_dados(atividades, uma_semana_atras):
             if res_pr.status_code == 200:
                 pr_data = res_pr.json()
                 if pr_data.get('merged_at') and pr_data['merged_at'] >= uma_semana_atras:
-                    if autor_item not in IGNORE_USERS:
+                    if not deve_ignorar(autor_item):
                         linhas = pr_data.get('additions', 0) + pr_data.get('deletions', 0)
                         data_badges["volume"][autor_item] += linhas
 
@@ -101,7 +104,7 @@ def processar_dados(atividades, uma_semana_atras):
                     match = re.search(REGEX_BADGE, comment.get('body', ''))
                     if match:
                         aluno_premiado = match.group(1)
-                        if aluno_premiado not in IGNORE_USERS:
+                        if not deve_ignorar(aluno_premiado):
                             badge_texto = match.group(2).strip()
                             for ranking_id, config in CONFIG_RANKINGS.items():
                                 if config['badge'] == badge_texto:
@@ -109,7 +112,7 @@ def processar_dados(atividades, uma_semana_atras):
                                     break
                 
                 # Conta métricas de comentário (próprio vs outros)
-                if autor_comentario not in IGNORE_USERS:
+                if not deve_ignorar(autor_comentario):
                     if autor_comentario == autor_item:
                         engajamento[autor_comentario]["com_proprio"] += 1
                     else:
@@ -129,7 +132,7 @@ def processar_dados(atividades, uma_semana_atras):
                         match = re.search(REGEX_BADGE, comment.get('body', ''))
                         if match:
                             aluno_premiado = match.group(1)
-                            if aluno_premiado not in IGNORE_USERS:
+                            if not deve_ignorar(aluno_premiado):
                                 badge_texto = match.group(2).strip()
                                 for ranking_id, config in CONFIG_RANKINGS.items():
                                     if config['badge'] == badge_texto:
@@ -137,13 +140,48 @@ def processar_dados(atividades, uma_semana_atras):
                                         break
                     
                     # Conta comentário como Code Review
-                    if autor_comentario not in IGNORE_USERS:
+                    if not deve_ignorar(autor_comentario):
                         engajamento[autor_comentario]["com_review"] += 1
 
     return data_badges, engajamento
 
-def atualizar_readme(data_badges):
-    """Atualiza o README apenas com as badges (pódio atual), mantendo o padrão."""
+def _detectar_newline(path):
+    """Detecta se o arquivo usa CRLF ou LF, pra preservar o estilo na escrita."""
+    with open(path, "rb") as f:
+        amostra = f.read(8192)
+    return "\r\n" if b"\r\n" in amostra else "\n"
+
+def ler_acumulado_historico():
+    """Lê o HISTORICO_PLACAR.md e retorna o total acumulado por aluno em cada ranking."""
+    acumulado = defaultdict(lambda: defaultdict(int))
+    if not os.path.exists("HISTORICO_PLACAR.md"):
+        return acumulado
+
+    titulo_para_id = {config["titulo"]: rid for rid, config in CONFIG_RANKINGS.items()}
+
+    with open("HISTORICO_PLACAR.md", "r", encoding="utf-8") as f:
+        conteudo = f.read()
+
+    ranking_atual = None
+    for linha in conteudo.split("\n"):
+        linha_strip = linha.strip()
+        m_titulo = re.match(r"^####\s+(.+)$", linha_strip)
+        if m_titulo:
+            ranking_atual = titulo_para_id.get(m_titulo.group(1).strip())
+            continue
+        if re.match(r"^#{1,3}\s", linha_strip):
+            ranking_atual = None
+            continue
+        if ranking_atual:
+            m = re.match(r"^\d+\.\s+\*\*@([\w-]+)\*\*\s+-\s+(\d+)", linha_strip)
+            if m:
+                acumulado[ranking_atual][m.group(1)] += int(m.group(2))
+
+    return acumulado
+
+def atualizar_readme(acumulado):
+    """Atualiza o README com o ranking acumulado lido do histórico completo."""
+    newline_readme = _detectar_newline("README.md")
     with open("README.md", "r", encoding="utf-8") as f:
         readme = f.read()
 
@@ -154,13 +192,12 @@ def atualizar_readme(data_badges):
         readme
     )
 
-
     for ranking_id, config in CONFIG_RANKINGS.items():
-        ranking_alunos = data_badges[ranking_id]
+        ranking_alunos = acumulado[ranking_id]
         titulo = config["titulo"]
 
         if not ranking_alunos:
-            texto_vencedores = "🥇 **Ainda não há registros nesta semana.**"
+            texto_vencedores = "🥇 **Ainda não há registros.**"
         else:
             sorted_alunos = sorted(ranking_alunos.items(), key=lambda item: item[1], reverse=True)
             top_aluno, top_score = sorted_alunos[0]
@@ -178,64 +215,74 @@ def atualizar_readme(data_badges):
         padrao = re.compile(rf"(### {re.escape(titulo)}.*?\n!\[.*?\]\(.*?\)\n+)(.*?)(?=\n+---)", re.DOTALL)
         readme = padrao.sub(f"\\g<1>{texto_vencedores}", readme)
 
-    with open("README.md", "w", encoding="utf-8") as f:
+    with open("README.md", "w", encoding="utf-8", newline=newline_readme) as f:
         f.write(readme)
     print("README.md atualizado com sucesso!")
 
 def atualizar_historico(data_badges, engajamento):
-    """Adiciona as métricas de engajamento e as badges no Histórico Semanal."""
+    """Adiciona/atualiza a seção da semana atual no HISTORICO_PLACAR.md (idempotente)."""
     data_formatada = datetime.now().strftime('%d/%m/%Y')
-    
+
     teve_pontuacao = any(len(alunos) > 0 for alunos in data_badges.values())
     teve_engajamento = len(engajamento) > 0
-    
+
     if not teve_pontuacao and not teve_engajamento:
         print("Nenhuma atividade nesta semana. Histórico não alterado.")
         return
 
-    md_historico = f"\n## 📅 Semana de {data_formatada}\n\n"
-    
-    # --- Nova Tabela de Engajamento ---
-    if teve_engajamento:
-        md_historico += "### 📊 Métricas de Engajamento da Semana\n"
-        md_historico += "| Aluno | Issues Abertas | PRs Abertos | Comentários (Próprios) | Comentários (Outros) | Code Reviews |\n"
-        md_historico += "| :--- | :---: | :---: | :---: | :---: | :---: |\n"
-        
-        # Ordena a tabela por quem teve o maior volume de interações totais
-        eng_ordenado = sorted(engajamento.items(), key=lambda x: sum(x[1].values()), reverse=True)
-        
-        for aluno, stats in eng_ordenado:
-            md_historico += f"| **@{aluno}** | {stats['issues']} | {stats['prs']} | {stats['com_proprio']} | {stats['com_outros']} | {stats['com_review']} |\n"
-        md_historico += "\n---\n\n"
+    md_secao = f"## 📅 Semana de {data_formatada}\n\n"
 
-    # --- Placar de Badges Tradicional ---
+    if teve_engajamento:
+        md_secao += "### 📊 Métricas de Engajamento da Semana\n"
+        md_secao += "| Aluno | Issues Abertas | PRs Abertos | Comentários (Próprios) | Comentários (Outros) | Code Reviews |\n"
+        md_secao += "| :--- | :---: | :---: | :---: | :---: | :---: |\n"
+        eng_ordenado = sorted(engajamento.items(), key=lambda x: sum(x[1].values()), reverse=True)
+        for aluno, stats in eng_ordenado:
+            md_secao += f"| **@{aluno}** | {stats['issues']} | {stats['prs']} | {stats['com_proprio']} | {stats['com_outros']} | {stats['com_review']} |\n"
+        md_secao += "\n---\n\n"
+
     if teve_pontuacao:
-        md_historico += "### 🏆 Badges Conquistadas\n"
+        md_secao += "### 🏆 Badges Conquistadas\n"
         for ranking_id, config in CONFIG_RANKINGS.items():
             ranking_alunos = data_badges[ranking_id]
             if not ranking_alunos:
                 continue
-                
-            md_historico += f"#### {config['titulo']}\n"
+            md_secao += f"#### {config['titulo']}\n"
             sorted_alunos = sorted(ranking_alunos.items(), key=lambda item: item[1], reverse=True)
-            
             for posicao, (aluno, score) in enumerate(sorted_alunos, start=1):
                 score_str = "linhas" if ranking_id == "volume" else "badges"
-                md_historico += f"{posicao}. **@{aluno}** - {score} {score_str}\n"
-            md_historico += "\n"
+                md_secao += f"{posicao}. **@{aluno}** - {score} {score_str}\n"
+            md_secao += "\n"
 
-    arquivo_existe = os.path.exists("HISTORICO_PLACAR.md")
-    with open("HISTORICO_PLACAR.md", "a", encoding="utf-8") as f:
-        if not arquivo_existe:
-            f.write("# 📚 Histórico Completo do Placar Semanal\n\n")
-            f.write("Registro contínuo das métricas de engajamento, pontuações e badges atribuídas.\n")
-        f.write(md_historico)
+    cabecalho = (
+        "# 📚 Histórico Completo do Placar Semanal\n\n"
+        "Registro contínuo das métricas de engajamento, pontuações e badges atribuídas.\n"
+    )
+
+    if os.path.exists("HISTORICO_PLACAR.md"):
+        newline_hist = _detectar_newline("HISTORICO_PLACAR.md")
+        with open("HISTORICO_PLACAR.md", "r", encoding="utf-8") as f:
+            conteudo = f.read()
+        # Remove seção existente da mesma data, se houver, pra manter idempotência
+        padrao_existente = re.compile(
+            rf"\n*## 📅 Semana de {re.escape(data_formatada)}\n.*?(?=\n## 📅 Semana de |\Z)",
+            re.DOTALL
+        )
+        conteudo = padrao_existente.sub("", conteudo)
+        conteudo = conteudo.rstrip() + "\n\n" + md_secao
+    else:
+        newline_hist = _detectar_newline("README.md") if os.path.exists("README.md") else "\n"
+        conteudo = cabecalho + "\n" + md_secao
+
+    with open("HISTORICO_PLACAR.md", "w", encoding="utf-8", newline=newline_hist) as f:
+        f.write(conteudo)
     print("HISTORICO_PLACAR.md atualizado com sucesso!")
 
 # --- EXECUÇÃO ---
 if __name__ == "__main__":
     atividades, uma_semana_atras = buscar_atividades_recentes()
     data_badges, engajamento = processar_dados(atividades, uma_semana_atras)
-    
-    atualizar_readme(data_badges)
+
     atualizar_historico(data_badges, engajamento)
+    acumulado = ler_acumulado_historico()
+    atualizar_readme(acumulado)

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -35,14 +35,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/gerar_placar.py
 
-      - name: Commit e push do placar atualizado
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md HISTORICO_PLACAR.md
-          if git diff --cached --quiet; then
-            echo "Nenhuma alteração no placar."
-          else
-            git commit -m "🤖 Robô do Placar: atualiza Hall da Fama"
-            git push origin main
-          fi
+      - name: Criar Pull Request com o Placar
+        uses: peter-evans/create-pull-request@v6 # Atualizado para remover o aviso do Node
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "🤖 Robô do Placar: Atualizando Hall da Fama"
+          title: "🏆 Atualização do Placar"
+          body: "Esta é uma PR automática gerada pelo script de gamificação para atualizar o README e o HISTORICO."
+          branch: "bot/atualizacao-placar"
+          base: "main"

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -35,12 +35,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/gerar_placar.py
 
-      - name: Criar Pull Request com o Placar
-        uses: peter-evans/create-pull-request@v6 # Atualizado para remover o aviso do Node
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "🤖 Robô do Placar: Atualizando Hall da Fama Semanal"
-          title: "🏆 Atualização do Placar Semanal"
-          body: "Esta é uma PR automática gerada pelo script de gamificação para atualizar o README e o HISTORICO."
-          branch: "bot/atualizacao-placar"
-          base: "main"
+      - name: Commit e push do placar atualizado
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md HISTORICO_PLACAR.md
+          if git diff --cached --quiet; then
+            echo "Nenhuma alteração no placar."
+          else
+            git commit -m "🤖 Robô do Placar: atualiza Hall da Fama"
+            git push origin main
+          fi

--- a/HISTORICO_PLACAR.md
+++ b/HISTORICO_PLACAR.md
@@ -1,0 +1,53 @@
+# 📚 Histórico Completo do Placar Semanal
+
+Registro contínuo das métricas de engajamento, pontuações e badges atribuídas.
+
+## 📅 Semana de 30/03/2026
+
+### 📊 Métricas de Engajamento da Semana
+| Aluno | Issues Abertas | PRs Abertos | Comentários (Próprios) | Comentários (Outros) | Code Reviews |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| **@Motaromc** | 0 | 1 | 0 | 0 | 2 |
+| **@sayydaviid** | 0 | 1 | 0 | 0 | 1 |
+| **@lorenarss** | 0 | 1 | 1 | 0 | 0 |
+| **@MarioDhiego** | 0 | 0 | 0 | 0 | 1 |
+
+---
+
+### 🏆 Badges Conquistadas
+#### ⌨️ Jack Bauer do Código
+1. **@Motaromc** - 289 linhas
+2. **@lorenarss** - 26 linhas
+
+#### 🧠 John Nash da turma
+1. **@Motaromc** - 1 badges
+
+## 📅 Semana de 13/04/2026
+
+### 📊 Métricas de Engajamento da Semana
+| Aluno | Issues Abertas | PRs Abertos | Comentários (Próprios) | Comentários (Outros) | Code Reviews |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| **@ygarasab** | 0 | 1 | 3 | 0 | 0 |
+| **@gabrielcostadev** | 0 | 1 | 0 | 0 | 0 |
+| **@yurisawaki** | 0 | 1 | 0 | 0 | 0 |
+| **@sayydaviid** | 0 | 0 | 0 | 1 | 0 |
+| **@Mylena1408** | 0 | 1 | 0 | 0 | 0 |
+| **@polysamo** | 0 | 1 | 0 | 0 | 0 |
+
+---
+
+### 🏆 Badges Conquistadas
+#### ⌨️ Jack Bauer do Código
+1. **@sayydaviid** - 314 linhas
+2. **@ygarasab** - 116 linhas
+
+## 📅 Semana de 20/04/2026
+
+### 🏆 Badges Conquistadas
+#### ⌨️ Jack Bauer do Código
+1. **@Motaromc** - 191 linhas
+2. **@ygarasab** - 169 linhas
+3. **@polysamo** - 162 linhas
+
+#### 🧠 John Nash da turma
+1. **@Motaromc** - 1 badges

--- a/README.md
+++ b/README.md
@@ -39,14 +39,22 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ## 🏆 Hall da Fama - Placar Semanal da Turma
 
-> 🤖 *O robô está aquecendo os motores... O primeiro placar oficial será atualizado neste domingo à noite!*
+> 🤖 *Placar atualizado automaticamente em: 05/05/2026 16:26*
 
 ### ⌨️ Jack Bauer do Código
 *Quem mais codificou na semana (Volume total de linhas mescladas)*
 
 ![Jack Bauer](/.github/images/memes/image_5.png)
 
-🥇 **Ainda não há registros. Faça o primeiro PR!** (0 linhas mescladas)
+🥇 **@Motaromc** (480 linhas mescladas)
+
+<details><summary>Ver Top 3 completo</summary>
+
+🥇 @Motaromc (480)
+🥈 @sayydaviid (314)
+🥉 @ygarasab (285)
+
+</details>
 
 ---
 
@@ -55,7 +63,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![John Coffey](/.github/images/memes/image_6.png)
 
-🥇 **Ainda não há registros. Ajude um colega!** (0 badges acumuladas)
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -64,7 +72,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Bug Catcher](/.github/images/memes/image_7.png)
 
-🥇 **Ainda não há registros. Encontre um erro!** (0 badges acumuladas)
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -73,7 +81,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Patrick Bateman](/.github/images/memes/image_8.png)
 
-🥇 **Ainda não há registros. Escreva um código impecável!** (0 badges acumuladas)
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -82,7 +90,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![John Nash](/.github/images/memes/image_9.png)
 
-🥇 **Ainda não há registros. Mostre sua genialidade!** (0 badges acumuladas)
+🥇 **@Motaromc** (2 badges acumuladas)
 
 ---
 
@@ -91,7 +99,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Da Vinci](/.github/images/memes/image_10.png)
 
-🥇 **Ainda não há registros. Capriche na interface!** (0 badges acumuladas)
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -100,7 +108,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Neo](/.github/images/memes/image_11.png)
 
-🥇 **Ainda não há registros. Manipule a matriz!** (0 badges acumuladas)
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -109,7 +117,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Gandalf](/.github/images/memes/image_12.png)
 
-🥇 **Ainda não há registros nesta semana.**
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -118,7 +126,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Sherlock](/.github/images/memes/image_13.png)
 
-🥇 **Ainda não há registros nesta semana.**
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -127,7 +135,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Heimdall](/.github/images/memes/image_14.png)
 
-🥇 **Ainda não há registros nesta semana.**
+🥇 **Ainda não há registros.**
 
 ---
 
@@ -136,7 +144,7 @@ As suas contribuições e Pull Requests (PRs) não valem apenas nota, mas també
 
 ![Edna](/.github/images/memes/image_15.png)
 
-🥇 **Ainda não há registros nesta semana.**
+🥇 **Ainda não há registros.**
 
 ---
 


### PR DESCRIPTION
closes #56.

contexto da discussao na issue: depois do diagnostico, originalmente propus dois itens — (1) trocar o create-pull-request por push direto na main pra resolver a persistencia, e (2) acumular badges no semestre todo em vez de zerar por semana. @gustavoresque liberou apenas o (2), mantendo a politica de nao ter push automatico sem supervisao. essa PR implementa so o (2).

mudancas no `.github/scripts/gerar_placar.py`:
- `atualizar_historico`: separado de `atualizar_readme`. escreve a secao da semana no `HISTORICO_PLACAR.md` de forma idempotente — se ja existir uma secao com a mesma data, ela é substituida em vez de duplicar.
- `ler_acumulado_historico`: nova funcao. le o `HISTORICO_PLACAR.md` inteiro e soma badges/linhas por aluno em cada ranking, retornando o estado acumulado do semestre.
- `atualizar_readme`: agora recebe o acumulado e renderiza o ranking cumulativo. score do ranking de volume mostra "linhas mescladas"; ranking de badges mostra "badges acumuladas".

mudancas no `.github/workflows/leaderboard.yml`:
- adicionada permissao explicita `pull-requests: write` que faltava pra abrir PR.
- forcado `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` pra remover warning de node.
- mantido `peter-evans/create-pull-request@v6` (conforme alinhado na issue).

`HISTORICO_PLACAR.md` ja sobe com as 3 semanas que conseguimos reconstruir do semestre (30/03, 13/04, 20/04). a partir do merge desta PR, cada rodada semanal do bot abre uma PR que, quando mergeada, soma a semana ao historico — e o README sempre reflete o acumulado.

teste local: rodei o `ler_acumulado_historico` no historico atual e o README ja renderiza @Motaromc com 480 linhas no Jack Bauer e 2 badges no John Nash, @ygarasab com 285 linhas, @sayydaviid com 314 linhas, @polysamo com 162 linhas. somatorias batem com as 3 secoes do historico.