### PR TITLE
Visualização de planos de bits

### DIFF
--- a/plugins/pixels/visualizacao_planos_bits.py
+++ b/plugins/pixels/visualizacao_planos_bits.py
@@ -4,9 +4,13 @@ plugins/pixels/visualizacao_planos_bits.py
 Plugin de visualização de planos de bits (*bit-plane slicing*).
 
 Permite selecionar um ou mais planos de bit (do bit 7, mais significativo, ao
-bit 0, menos significativo) e visualizá-los como uma imagem binária: cada pixel
-fica branco (255) quando *algum* dos bits selecionados está ligado e preto (0)
-caso contrário.  Útil para inspecionar a contribuição de cada plano.
+bit 0, menos significativo) e visualizá-los de duas formas:
+
+* **Plano binário** — cada pixel fica branco (255) quando *algum* dos bits
+  selecionados está ligado e preto (0) caso contrário.  Útil para inspecionar
+  um plano isolado.
+* **Reconstrução** — mantém apenas os bits selecionados no seu peso original e
+  zera os demais, evidenciando a contribuição daqueles planos para a imagem.
 
 A operação é feita sobre a intensidade em tons de cinza (clássico de Gonzalez).
 """
@@ -14,11 +18,13 @@ A operação é feita sobre a intensidade em tons de cinza (clássico de Gonzale
 import numpy as np
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
+    QButtonGroup,
     QCheckBox,
     QGridLayout,
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QRadioButton,
     QVBoxLayout,
 )
 
@@ -51,6 +57,17 @@ class VisualizacaoPlanosBits(PluginBase):
         # Começa com o bit mais significativo marcado para um preview imediato.
         self._checks_bit[7].setChecked(True)
 
+        # --- Modo de exibição ---
+        layout_principal.addWidget(QLabel("Modo de exibição:", self))
+        self._grupo_modo = QButtonGroup(self)
+        self._radios_modo: dict[str, QRadioButton] = {}
+        for texto, valor in [("Plano binário", "binario"), ("Reconstrução", "reconstrucao")]:
+            radio = QRadioButton(texto, self)
+            self._grupo_modo.addButton(radio)
+            self._radios_modo[valor] = radio
+            layout_principal.addWidget(radio)
+        self._radios_modo["binario"].setChecked(True)
+
         self._rotulo_status = QLabel(self)
         self._rotulo_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout_principal.addWidget(self._rotulo_status)
@@ -68,6 +85,8 @@ class VisualizacaoPlanosBits(PluginBase):
 
         for check in self._checks_bit.values():
             check.toggled.connect(self._ao_mudar_controle)
+        for radio in self._radios_modo.values():
+            radio.toggled.connect(self._ao_mudar_controle)
 
         self.setLayout(layout_principal)
         self.setMinimumWidth(320)
@@ -77,6 +96,15 @@ class VisualizacaoPlanosBits(PluginBase):
 
     def _bits_selecionados(self) -> list[int]:
         return [bit for bit, check in self._checks_bit.items() if check.isChecked()]
+
+    def _modo(self) -> str:
+        return "reconstrucao" if self._radios_modo["reconstrucao"].isChecked() else "binario"
+
+    def _fatiar(self, canais: np.ndarray, mascara: int, modo: str) -> np.ndarray:
+        """Aplica o fatiamento de bits a um array uint8 (qualquer formato)."""
+        if modo == "binario":
+            return np.where((canais & mascara) > 0, 255, 0).astype(np.uint8)
+        return (canais & mascara).astype(np.uint8)
 
     def processar(self, imagem: np.ndarray) -> np.ndarray:
         bits = self._bits_selecionados()
@@ -90,7 +118,7 @@ class VisualizacaoPlanosBits(PluginBase):
 
         rgb = imagem[..., :3].astype(np.uint16)
         cinza = np.rint((rgb[..., 0] + rgb[..., 1] + rgb[..., 2]) / 3.0).astype(np.uint8)
-        resultado = np.where((cinza & mascara) > 0, 255, 0).astype(np.uint8)
+        resultado = self._fatiar(cinza, mascara, self._modo())
         return np.stack((resultado, resultado, resultado), axis=-1)
 
     def _texto_status(self) -> str:
@@ -98,7 +126,7 @@ class VisualizacaoPlanosBits(PluginBase):
         if not bits:
             return "Nenhum plano selecionado"
         lista = ", ".join(str(bit) for bit in sorted(bits, reverse=True))
-        return f"Planos: {lista}"
+        return f"Planos: {lista}  |  {self._radios_modo[self._modo()].text()}"
 
     def _emitir_preview(self) -> None:
         self._rotulo_status.setText(self._texto_status())

--- a/plugins/pixels/visualizacao_planos_bits.py
+++ b/plugins/pixels/visualizacao_planos_bits.py
@@ -12,7 +12,8 @@ bit 0, menos significativo) e visualizá-los de duas formas:
 * **Reconstrução** — mantém apenas os bits selecionados no seu peso original e
   zera os demais, evidenciando a contribuição daqueles planos para a imagem.
 
-A operação é feita sobre a intensidade em tons de cinza (clássico de Gonzalez).
+A operação pode ser feita sobre a intensidade em tons de cinza (clássico de
+Gonzalez) ou canal a canal sobre o RGB, preservando a cor.
 """
 
 import numpy as np
@@ -57,6 +58,17 @@ class VisualizacaoPlanosBits(PluginBase):
         # Começa com o bit mais significativo marcado para um preview imediato.
         self._checks_bit[7].setChecked(True)
 
+        # --- Domínio: tons de cinza ou por canal RGB ---
+        layout_principal.addWidget(QLabel("Domínio:", self))
+        self._grupo_dominio = QButtonGroup(self)
+        self._radios_dominio: dict[str, QRadioButton] = {}
+        for texto, valor in [("Tons de cinza", "cinza"), ("Por canal RGB", "rgb")]:
+            radio = QRadioButton(texto, self)
+            self._grupo_dominio.addButton(radio)
+            self._radios_dominio[valor] = radio
+            layout_principal.addWidget(radio)
+        self._radios_dominio["cinza"].setChecked(True)
+
         # --- Modo de exibição ---
         layout_principal.addWidget(QLabel("Modo de exibição:", self))
         self._grupo_modo = QButtonGroup(self)
@@ -85,7 +97,7 @@ class VisualizacaoPlanosBits(PluginBase):
 
         for check in self._checks_bit.values():
             check.toggled.connect(self._ao_mudar_controle)
-        for radio in self._radios_modo.values():
+        for radio in (*self._radios_dominio.values(), *self._radios_modo.values()):
             radio.toggled.connect(self._ao_mudar_controle)
 
         self.setLayout(layout_principal)
@@ -96,6 +108,9 @@ class VisualizacaoPlanosBits(PluginBase):
 
     def _bits_selecionados(self) -> list[int]:
         return [bit for bit, check in self._checks_bit.items() if check.isChecked()]
+
+    def _dominio(self) -> str:
+        return "rgb" if self._radios_dominio["rgb"].isChecked() else "cinza"
 
     def _modo(self) -> str:
         return "reconstrucao" if self._radios_modo["reconstrucao"].isChecked() else "binario"
@@ -116,10 +131,17 @@ class VisualizacaoPlanosBits(PluginBase):
         if mascara == 0:
             return np.zeros_like(imagem)
 
-        rgb = imagem[..., :3].astype(np.uint16)
-        cinza = np.rint((rgb[..., 0] + rgb[..., 1] + rgb[..., 2]) / 3.0).astype(np.uint8)
-        resultado = self._fatiar(cinza, mascara, self._modo())
-        return np.stack((resultado, resultado, resultado), axis=-1)
+        modo = self._modo()
+
+        if self._dominio() == "cinza":
+            rgb = imagem[..., :3].astype(np.uint16)
+            cinza = np.rint((rgb[..., 0] + rgb[..., 1] + rgb[..., 2]) / 3.0).astype(np.uint8)
+            resultado = self._fatiar(cinza, mascara, modo)
+            return np.stack((resultado, resultado, resultado), axis=-1)
+
+        saida = imagem.copy()
+        saida[..., :3] = self._fatiar(imagem[..., :3], mascara, modo)
+        return saida
 
     def _texto_status(self) -> str:
         bits = self._bits_selecionados()

--- a/plugins/pixels/visualizacao_planos_bits.py
+++ b/plugins/pixels/visualizacao_planos_bits.py
@@ -1,0 +1,114 @@
+"""
+plugins/pixels/visualizacao_planos_bits.py
+-------------------------------------------
+Plugin de visualização de planos de bits (*bit-plane slicing*).
+
+Permite selecionar um ou mais planos de bit (do bit 7, mais significativo, ao
+bit 0, menos significativo) e visualizá-los como uma imagem binária: cada pixel
+fica branco (255) quando *algum* dos bits selecionados está ligado e preto (0)
+caso contrário.  Útil para inspecionar a contribuição de cada plano.
+
+A operação é feita sobre a intensidade em tons de cinza (clássico de Gonzalez).
+"""
+
+import numpy as np
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from core.plugin_base import PluginBase
+
+
+class VisualizacaoPlanosBits(PluginBase):
+    display_name = "Planos de Bits"
+
+    def setup_ui(self) -> None:
+        layout_principal = QVBoxLayout(self)
+
+        # --- Seleção de planos de bit (do MSB ao LSB) ---
+        layout_principal.addWidget(QLabel("Planos de bit:", self))
+
+        self._checks_bit: dict[int, QCheckBox] = {}
+        grade_bits = QGridLayout()
+        for posicao, bit in enumerate(range(7, -1, -1)):
+            if bit == 7:
+                rotulo = f"Bit {bit} (MSB)"
+            elif bit == 0:
+                rotulo = f"Bit {bit} (LSB)"
+            else:
+                rotulo = f"Bit {bit}"
+            check = QCheckBox(rotulo, self)
+            self._checks_bit[bit] = check
+            grade_bits.addWidget(check, posicao // 2, posicao % 2)
+        layout_principal.addLayout(grade_bits)
+
+        # Começa com o bit mais significativo marcado para um preview imediato.
+        self._checks_bit[7].setChecked(True)
+
+        self._rotulo_status = QLabel(self)
+        self._rotulo_status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout_principal.addWidget(self._rotulo_status)
+
+        # --- Botões ---
+        layout_botoes = QHBoxLayout()
+        self._btn_aplicar = QPushButton("Aplicar", self)
+        self._btn_cancelar = QPushButton("Cancelar", self)
+        layout_botoes.addWidget(self._btn_aplicar)
+        layout_botoes.addWidget(self._btn_cancelar)
+        layout_principal.addLayout(layout_botoes)
+
+        self._btn_aplicar.clicked.connect(self._ao_aplicar)
+        self._btn_cancelar.clicked.connect(self.reject)
+
+        for check in self._checks_bit.values():
+            check.toggled.connect(self._ao_mudar_controle)
+
+        self.setLayout(layout_principal)
+        self.setMinimumWidth(320)
+
+        # Força o preview após o render da janela.
+        QTimer.singleShot(100, self._emitir_preview)
+
+    def _bits_selecionados(self) -> list[int]:
+        return [bit for bit, check in self._checks_bit.items() if check.isChecked()]
+
+    def processar(self, imagem: np.ndarray) -> np.ndarray:
+        bits = self._bits_selecionados()
+        mascara = 0
+        for bit in bits:
+            mascara |= 1 << bit
+
+        # Nenhum plano selecionado: imagem totalmente preta (contribuição nula).
+        if mascara == 0:
+            return np.zeros_like(imagem)
+
+        rgb = imagem[..., :3].astype(np.uint16)
+        cinza = np.rint((rgb[..., 0] + rgb[..., 1] + rgb[..., 2]) / 3.0).astype(np.uint8)
+        resultado = np.where((cinza & mascara) > 0, 255, 0).astype(np.uint8)
+        return np.stack((resultado, resultado, resultado), axis=-1)
+
+    def _texto_status(self) -> str:
+        bits = self._bits_selecionados()
+        if not bits:
+            return "Nenhum plano selecionado"
+        lista = ", ".join(str(bit) for bit in sorted(bits, reverse=True))
+        return f"Planos: {lista}"
+
+    def _emitir_preview(self) -> None:
+        self._rotulo_status.setText(self._texto_status())
+        self.preview_requested.emit(self.processar(self.imagem_original))
+
+    def _ao_mudar_controle(self, _marcado: bool = False) -> None:
+        self._emitir_preview()
+
+    def _ao_aplicar(self) -> None:
+        imagem_processada = self.processar(self.imagem_original)
+        self.preview_requested.emit(imagem_processada)
+        self.apply_requested.emit(imagem_processada)
+        self.accept()


### PR DESCRIPTION
Fecha #89.

Adiciona o plugin **Planos de Bits** (menu Pixels), que permite selecionar e visualizar um ou mais planos de bit de uma imagem (*bit-plane slicing*).

## o que faz
- seleção múltipla de planos via checkboxes, do bit 7 (msb) ao bit 0 (lsb)
- **domínio**: tons de cinza (clássico de gonzalez) ou canal a canal sobre o rgb, preservando a cor
- **modo de exibição**:
  - *plano binário* — pixel branco quando algum bit selecionado está ligado, preto caso contrário (bom pra inspecionar um plano isolado)
  - *reconstrução* — mantém os bits selecionados no peso original e zera o resto, mostrando a contribuição daqueles planos
- preview ao vivo conforme os controles mudam; abre já com o bit 7 marcado

## notas
- nenhum plano selecionado → imagem preta (contribuição nula); reconstrução com todos os bits volta idêntica à original (cinza ou rgb)

um adendo aqui, eu achei esse aqui particularmente divertido de brincar, jogar pro rgb e ficar olhando os planos de bits eh bem curioso, recomendo.

avalia nois @gustavoresque 