### PR TITLE
Adiciona atalhos e padroniza nomes

### DIFF
--- a/app.py
+++ b/app.py
@@ -199,7 +199,7 @@ def _carregar_classes_do_arquivo(caminho_arquivo: str) -> list[type]:
 
 def _formatar_nome_menu(nome_pasta: str) -> str:
     """Retorna o nome da pasta sem alterações para uso no submenu."""
-    return nome_pasta
+    return nome_pasta.capitalize()
 
 
 def carregar_plugins_dinamicamente(

--- a/app.py
+++ b/app.py
@@ -361,7 +361,7 @@ class TelaBoasVindas(QWidget):
         btn_nova = QPushButton("Nova Imagem")
         btn_nova.setFixedSize(130, 40)
 
-        btn_abrir = QPushButton("Abrir imagem…")
+        btn_abrir = QPushButton("Abrir imagem")
         btn_abrir.setFixedSize(130, 40)
         btn_abrir.clicked.connect(self.janela.abrir_imagem)
 
@@ -652,10 +652,9 @@ class JanelaPrincipal(QMainWindow):
         acao_nova_aba.triggered.connect(self.abrir_nova_aba)
         menu_arquivo.addSeparator()
         
-        acao_abrir = menu_arquivo.addAction("Abrir imagem…")
+        acao_abrir = menu_arquivo.addAction("Abrir imagem")
         acao_abrir.triggered.connect(self.abrir_imagem)
 
-        # NOVO: Adicionar opção de captura
         acao_camera = menu_arquivo.addAction("Capturar da Câmera")
         acao_camera.setShortcut("Ctrl+K")
         acao_camera.triggered.connect(self.capturar_da_camera)
@@ -663,7 +662,7 @@ class JanelaPrincipal(QMainWindow):
         acao_colar = menu_arquivo.addAction("Colar do clipboard")
         acao_colar.triggered.connect(self.colar_imagem_clipboard)
 
-        acao_salvar = menu_arquivo.addAction("Salvar imagem…")
+        acao_salvar = menu_arquivo.addAction("Salvar imagem")
         acao_salvar.triggered.connect(self.salvar_imagem)
         menu_arquivo.addSeparator()
         acao_sair = menu_arquivo.addAction("Sair")

--- a/app.py
+++ b/app.py
@@ -653,6 +653,7 @@ class JanelaPrincipal(QMainWindow):
         menu_arquivo.addSeparator()
         
         acao_abrir = menu_arquivo.addAction("Abrir imagem")
+        acao_abrir.setShortcut("Ctrl+O")
         acao_abrir.triggered.connect(self.abrir_imagem)
 
         acao_camera = menu_arquivo.addAction("Capturar da Câmera")
@@ -660,11 +661,14 @@ class JanelaPrincipal(QMainWindow):
         acao_camera.triggered.connect(self.capturar_da_camera)
         
         acao_colar = menu_arquivo.addAction("Colar do clipboard")
+        acao_colar.setShortcut("Ctrl+V")
         acao_colar.triggered.connect(self.colar_imagem_clipboard)
 
         acao_salvar = menu_arquivo.addAction("Salvar imagem")
+        acao_salvar.setShortcut("Ctrl+S")
         acao_salvar.triggered.connect(self.salvar_imagem)
         menu_arquivo.addSeparator()
+
         acao_sair = menu_arquivo.addAction("Sair")
         acao_sair.triggered.connect(self.close)
         


### PR DESCRIPTION
Adiciona funcionalidades descritas na issue #110 

- Atalho Ctrl + O para abrir imagem
- Atalho Ctrl + S para salvar imagem
- Atalho Ctrl + V para colar imagem do clipboard
- Remove reticências do nome das funções "abrir imagem" e "salvar imagem"
- Coloca o nome da função "Transformar" com primeira letra maiúscula

@gustavoresque por favor, verifique se está tudo apto para merge