### PR TITLE
Adiciona plugin de extração dos canais RGB

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,6 +202,7 @@ def _formatar_nome_menu(nome_pasta: str) -> str:
     return nome_pasta.capitalize()
 
 
+
 def carregar_plugins_dinamicamente(
     menu_pai: QMenu,
     diretorio: str,
@@ -255,6 +256,7 @@ def carregar_plugins_dinamicamente(
                     lambda _checked=False, cls=classe_plugin: janela_principal.abrir_plugin(cls)
                 )
 
+    
 # ---------------------------------------------------------------------------
 # Classes de Estado
 # ---------------------------------------------------------------------------
@@ -266,6 +268,8 @@ class DocumentoImagem(QWidget):
     """
     # Cria um sinal para repassar a alteração de zoom para a janela principal
     zoom_alterado = Signal(float)
+
+    
 
     def __init__(self, caminho_arquivo: str, imagem_bgr: np.ndarray, parent=None):
         super().__init__(parent)
@@ -1100,6 +1104,11 @@ class JanelaPrincipal(QMainWindow):
         dialogo.preview_requested.connect(lambda rgb: self._ao_receber_preview(rgb, aba_atual))
         dialogo.apply_requested.connect(lambda rgb: self._ao_aplicar_plugin(rgb, aba_atual))
 
+        if hasattr(dialogo, "multiple_images_requested"):
+            dialogo.multiple_images_requested.connect(
+                lambda imagens: self._ao_aplicar_multiplas_imagens(imagens, aba_atual)
+            )
+
         # Se o usuário fechar sem aplicar, restaura a imagem original
         dialogo.finished.connect(lambda codigo: self._ao_fechar_plugin(codigo, aba_atual))
 
@@ -1180,6 +1189,32 @@ class JanelaPrincipal(QMainWindow):
         self._marcar_como_modificado(aba, True)
 
         self.statusBar().showMessage("Filtro aplicado com sucesso.")
+
+    def _ao_aplicar_multiplas_imagens(self, imagens_rgb, aba_atual):
+        """Cria novas abas a partir de múltiplas imagens RGB geradas por um plugin."""
+        if not isinstance(aba_atual, DocumentoImagem):
+            return
+
+        nome_base = os.path.splitext(os.path.basename(aba_atual.caminho))[0]
+        if not nome_base:
+            nome_base = "Imagem"
+
+        for nome_canal, imagem_rgb in imagens_rgb:
+            imagem_bgr = cv2.cvtColor(imagem_rgb, cv2.COLOR_RGB2BGR)
+
+            nome_aba = f"{nome_base} - {nome_canal}"
+            caminho_ficticio = f"/{nome_aba}.png"
+
+            self._adicionar_documento_imagem(
+                caminho_ficticio,
+                imagem_bgr,
+                nome_aba=nome_aba,
+                tooltip=f"{nome_aba} (Não salvo)",
+                modificado=True,
+            )
+
+        aba_atual.imagem_backup = None
+        self.statusBar().showMessage("Canais RGB gerados em abas separadas.")
 
     def desfazer(self) -> None:
         """Desfaz a última operação aplicada."""

--- a/app.py
+++ b/app.py
@@ -202,7 +202,6 @@ def _formatar_nome_menu(nome_pasta: str) -> str:
     return nome_pasta.capitalize()
 
 
-
 def carregar_plugins_dinamicamente(
     menu_pai: QMenu,
     diretorio: str,
@@ -261,7 +260,6 @@ def carregar_plugins_dinamicamente(
                     lambda _checked=False, cls=classe_plugin: janela_principal.abrir_plugin(cls)
                 )
 
-    
 # ---------------------------------------------------------------------------
 # Classes de Estado
 # ---------------------------------------------------------------------------
@@ -273,8 +271,6 @@ class DocumentoImagem(QWidget):
     """
     # Cria um sinal para repassar a alteração de zoom para a janela principal
     zoom_alterado = Signal(float)
-
-    
 
     def __init__(self, caminho_arquivo: str, imagem_bgr: np.ndarray, parent=None):
         super().__init__(parent)

--- a/plugins/pixels/filtro_canais_rgb.py
+++ b/plugins/pixels/filtro_canais_rgb.py
@@ -1,0 +1,92 @@
+import numpy as np
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QLabel,
+    QPushButton,
+    QRadioButton,
+    QVBoxLayout,
+)
+
+from core.plugin_base import PluginBase
+
+
+class FiltroCanaisRGB(PluginBase):
+    display_name = "Extração de Canais RGB"
+
+    multiple_images_requested = Signal(list)
+
+    def __init__(self, imagem_rgb: np.ndarray, parent=None):
+        super().__init__(imagem_rgb, parent)
+
+        self.imagem_rgb = imagem_rgb.copy()
+
+        self.setWindowTitle("Extração de Canais RGB")
+
+        layout = QVBoxLayout(self)
+
+        descricao = QLabel(
+            "Gera três imagens separadas a partir dos canais RGB:\n"
+            "Canal vermelho, canal verde e canal azul."
+        )
+        layout.addWidget(descricao)
+
+        self.radio_colorido = QRadioButton("Manter canal colorido e zerar os outros")
+        self.radio_cinza = QRadioButton("Gerar canais em escala de cinza")
+
+        self.radio_colorido.setChecked(True)
+
+        grupo = QButtonGroup(self)
+        grupo.addButton(self.radio_colorido)
+        grupo.addButton(self.radio_cinza)
+
+        layout.addWidget(self.radio_colorido)
+        layout.addWidget(self.radio_cinza)
+
+        botao_gerar = QPushButton("Gerar 3 imagens")
+        botao_gerar.clicked.connect(self._gerar_canais)
+        layout.addWidget(botao_gerar)
+
+    def _gerar_canais(self) -> None:
+        imagem = self.imagem_rgb[:, :, :3]
+
+        if self.radio_cinza.isChecked():
+            canais = self._gerar_canais_em_cinza(imagem)
+        else:
+            canais = self._gerar_canais_coloridos(imagem)
+
+        self.multiple_images_requested.emit(canais)
+        self.accept()
+
+    def _gerar_canais_coloridos(
+        self,
+        imagem: np.ndarray,
+    ) -> list[tuple[str, np.ndarray]]:
+        canal_r = np.zeros_like(imagem)
+        canal_g = np.zeros_like(imagem)
+        canal_b = np.zeros_like(imagem)
+
+        canal_r[:, :, 0] = imagem[:, :, 0]
+        canal_g[:, :, 1] = imagem[:, :, 1]
+        canal_b[:, :, 2] = imagem[:, :, 2]
+
+        return [
+            ("Canal R", canal_r),
+            ("Canal G", canal_g),
+            ("Canal B", canal_b),
+        ]
+
+    def _gerar_canais_em_cinza(
+        self,
+        imagem: np.ndarray,
+    ) -> list[tuple[str, np.ndarray]]:
+        canal_r = np.repeat(imagem[:, :, 0:1], 3, axis=2)
+        canal_g = np.repeat(imagem[:, :, 1:2], 3, axis=2)
+        canal_b = np.repeat(imagem[:, :, 2:3], 3, axis=2)
+
+        return [
+            ("Canal R Cinza", canal_r),
+            ("Canal G Cinza", canal_g),
+            ("Canal B Cinza", canal_b),
+        ]


### PR DESCRIPTION
Este Pull Request adiciona um plugin de extração dos canais RGB da imagem. A funcionalidade permite gerar três imagens separadas a partir da imagem original, correspondentes aos canais vermelho, verde e azul, facilitando a análise individual da composição de cores. A implementação cria o plugin de extração de canais RGB na categoria Pixels, gera as imagens dos canais R, G e B, abre os resultados em novas abas da aplicação e preserva a imagem original durante o processo. Também foi feito um ajuste na integração dos plugins para permitir que um plugin gere múltiplas imagens como saída. Para testar, basta abrir a aplicação, carregar uma imagem, acessar o menu Pixels, selecionar o plugin de extração dos canais RGB, gerar os canais e verificar se três novas abas são criadas, uma para cada canal. A implementação segue a proposta discutida na issue, gerando três imagens para análise separada dos canais RGB.
