### PR TITLE
125 rastreamento de objetos por cor

### DIFF
--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -6,15 +6,15 @@ Plugin de exemplo: binarização interativa de imagens via slider.
 A implementação segue três etapas:
 
 1) Seleção do canal base da imagem RGB de entrada .
-2) Conversão do canal escolhido para tons de cinza (Canal R, Canal G, Canal B, Média RGB ou HSV).
+2) Conversão do canal escolhido para tons de cinza (Canal R, Canal G, Canal B, Média RGB ou Canal HSV).
 3) Aplicação do threshold para separar os pixels em dois grupos: pretos (0) e brancos (255) baseado no valor de limiar.
 
 Onde:
 * O método de extração pode ser R, G, B ou Média RGB.
 * Limiar (threshold) está no intervalo [0, 255].
-* Matriz (H) do espaço HSV.
+* Matiz (H) do espaço HSV.
 * Saturação (S) do espaço HSV.
-* Value/Brilho (V) do espaço HSV.
+* Valor/Brilho (V) do espaço HSV.
 
 Observações:
 * Quando um canal HSV é selecionado, a imagem de entrada é convertida de RBG para HSV utilizando cv.cvtColor().
@@ -60,6 +60,7 @@ class FiltroBinarizacao(PluginBase):
             ("Canal Vermelho (R)", "r"),
             ("Canal Verde (G)", "g"),
             ("Canal Azul (B)", "b"),
+            ()
             ]
         
         for texto, valor in opcoes:

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -45,7 +45,9 @@ class FiltroBinarizacao(PluginBase):
     # ------------------------------------------------------------------
 
     def setup_ui(self) -> None:
-        """Cria o slider de seleção do limiar (threshold), opções de canalRGB e os botões Aplicar/Cancelar."""
+        """
+        Cria o slider de seleção do limiar (threshold) e opções de canalRGB, opções do canal HSV e os botões Aplicar/Cancelar.
+        """
         layout_principal = QVBoxLayout(self)
         
         # --- Seleção da Origem da Imagem ---

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -171,6 +171,25 @@ class FiltroBinarizacao(PluginBase):
         """Regera o processamento para mostrar o preview ao vivo no canvas."""
         if not marcado:
             return
+        
+        # Bloqueia os sinais para evitar que o evento valueChanged dipare loops indesejados
+        self._slider_limiar.blockSignals(True)
+
+
+        metodo = self._obter_metodo()
+        if metodo == "h":
+            self._slider_limiar.setRange(0, 179)  # Canal H: 0-179
+            if self._slider_limiar.value() > 179:
+                self._slider_limiar.setValue(179)  # Ajusta o valor do slider se estiver fora do range
+        else:
+            self._slider_limiar.setRange(0, 255)  # Aos demais canais: 0-255
+
+        self._slider_limiar.blockSignals(False) 
+
+        # Garante que o teXto eXiba o valor real do slider apos o ajuste do range
+        valor_atual = self._slider_limiar.value()
+        self._rotulo_limiar.setText(f"Limiar (Threshold): {valor_atual}")       
+
         # Utiliza a cópia da imagem enviada pelo construtor da PluginBase
         imagem_processada = self.processar(self.imagem_original)
         self.preview_requested.emit(imagem_processada)

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -17,7 +17,7 @@ Onde:
 * Valor/Brilho (V) do espaço HSV.
 
 Observações:
-* Quando um canal HSV é selecionado, a imagem de entrada é convertida de RBG para HSV utilizando cv.cvtColor().
+* Quando um canal HSV é selecionado, a imagem de entrada é convertida de RBG para HSV utilizando cv2.cvtColor().
 * No OpenCV, o canal H possui faixa de valores entre 0 e 179, enquanto S e V possuem faixa entre 0 e 255. Portanto, o slider de limiar deve ser ajustado de acordo com o canal selecionado.
 """
 
@@ -37,7 +37,9 @@ from PySide6.QtWidgets import (
 from core.plugin_base import PluginBase
 
 class FiltroBinarizacao(PluginBase):
-    """Plugin para binarização da imagem"""
+    """
+    Plugin para binarização da imagem
+    """
     display_name = "Binarização"
 
     # ------------------------------------------------------------------
@@ -115,11 +117,14 @@ class FiltroBinarizacao(PluginBase):
         self._ao_alterar_parametros(True)
 
     def _obter_metodo(self) -> str:
-        """Verifica qual rádio button está marcado e retorna a sua chave."""
+        """
+        Verifica qual rádio button está marcado e retorna a sua chave.
+        """
         for valor, radio in self._radios_metodo.items():
             if radio.isChecked():
                 return valor
         return "media"
+    
 
     def processar(self, imagem: np.ndarray) -> np.ndarray:
         """
@@ -135,7 +140,7 @@ class FiltroBinarizacao(PluginBase):
 
         # 2º Verifica se o método selecionado é um canal HSV. Se for, converte a imagem para HSV.
 
-        if metodo in ["h", "s", "v"]:
+        if metodo in {"h", "s", "v"}:
             imagem_hsv = cv2.cvtColor(imagem, cv2.COLOR_RGB2HSV)
             if metodo == "h":
                 canal_base = imagem_hsv[..., 0]  # Matiz (0-179)
@@ -161,14 +166,20 @@ class FiltroBinarizacao(PluginBase):
         # O motor de renderização principal (app.py) espera uma imagem com 3 dimensões (RGB).
         # Empilha o resultado binário (1 canal) nos três canais finais
         return np.stack((img_bin, img_bin, img_bin), axis=-1)
+    
 
     def _ao_mover_slider(self, valor: int) -> None:
-        """Atualiza o texto da interface quando o slider é movimentado."""
+        """
+        Atualiza o texto da interface quando o slider é movimentado.
+        """
         self._rotulo_limiar.setText(f"Limiar (Threshold): {valor}")
         self._ao_alterar_parametros(True)
 
+
     def _ao_alterar_parametros(self, marcado: bool) -> None:
-        """Regera o processamento para mostrar o preview ao vivo no canvas."""
+        """
+        Regera o processamento para mostrar o preview ao vivo no canvas.
+        """
         if not marcado:
             return
         
@@ -195,7 +206,9 @@ class FiltroBinarizacao(PluginBase):
         self.preview_requested.emit(imagem_processada)
 
     def _ao_aplicar(self) -> None:
-        """Aplica o filtro na matriz oficial e adiciona ao histórico."""
+        """
+        Aplica o filtro na matriz oficial e adiciona ao histórico.
+        """
         imagem_processada = self.processar(self.imagem_original)
         self.apply_requested.emit(imagem_processada)
         self.accept()

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -60,7 +60,11 @@ class FiltroBinarizacao(PluginBase):
             ("Canal Vermelho (R)", "r"),
             ("Canal Verde (G)", "g"),
             ("Canal Azul (B)", "b"),
-            ()
+
+            # 1º Atualização a interface. Novas Opções do Canal HSV.
+            ("Matiz (H)", "h"),
+            ("Saturação (S)", "s"),
+            ("Valor/Brilho (V)", "v"),
             ]
         
         for texto, valor in opcoes:

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -122,12 +122,30 @@ class FiltroBinarizacao(PluginBase):
         return "media"
 
     def processar(self, imagem: np.ndarray) -> np.ndarray:
-        """Lógica matemática executada a cada alteração nos controles."""
+        """
+        Lógica matemática executada a cada alteração nos controles.
+        
+        Converter a imagem RGB para HSV usando cv2.cvtColor().
+        """
         metodo = self._obter_metodo()
         limiar = self._slider_limiar.value()
 
         # O app.py envia a imagem no formato RGB.
         # Extraí o canal escolhido via slicing:
+
+        # 2º Verifica se o método selecionado é um canal HSV. Se for, converte a imagem para HSV.
+
+        if metodo in ["h", "s", "v"]:
+            #Converte a imagem de RGB para HSV
+            imagem_hsv = cv2.cvtColor(imagem, cv2.COLOR_RGB2HSV)
+            if metodo == "h":
+                canal_base = imagem_hsv[..., 0]  # Canal H (Matiz)
+            elif metodo == "s":
+                canal_base = imagem_hsv[..., 1]  # Canal S (Saturação)
+            elif metodo == "v":
+                canal_base = imagem_hsv[..., 2]  # Canal V (Valor/Brilho)
+        
+        # lógica RBG original
         if metodo == "r":
             canal_base = imagem[..., 0]
         elif metodo == "g":

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -5,13 +5,20 @@ Plugin de exemplo: binarização interativa de imagens via slider.
 
 A implementação segue três etapas:
 
-1) Seleção do canal base da imagem RGB de entrada (Canal R, Canal G, Canal B ou a Média dos 3).
-2) Conversão do canal escolhido para tons de cinza.
+1) Seleção do canal base da imagem RGB de entrada .
+2) Conversão do canal escolhido para tons de cinza (Canal R, Canal G, Canal B, Média RGB ou HSV).
 3) Aplicação do threshold para separar os pixels em dois grupos: pretos (0) e brancos (255) baseado no valor de limiar.
 
 Onde:
 * O método de extração pode ser R, G, B ou Média RGB.
 * Limiar (threshold) está no intervalo [0, 255].
+* Matriz (H) do espaço HSV.
+* Saturação (S) do espaço HSV.
+* Value/Brilho (V) do espaço HSV.
+
+Observações:
+* Quando um canal HSV é selecionado, a imagem de entrada é convertida de RBG para HSV utilizando cv.cvtColor().
+* No OpenCV, o canal H possui faixa de valores entre 0 e 179, enquanto S e V possuem faixa entre 0 e 255. Portanto, o slider de limiar deve ser ajustado de acordo com o canal selecionado.
 """
 
 import cv2

--- a/plugins/pixels/filtro_binarizacao.py
+++ b/plugins/pixels/filtro_binarizacao.py
@@ -136,17 +136,14 @@ class FiltroBinarizacao(PluginBase):
         # 2º Verifica se o método selecionado é um canal HSV. Se for, converte a imagem para HSV.
 
         if metodo in ["h", "s", "v"]:
-            #Converte a imagem de RGB para HSV
             imagem_hsv = cv2.cvtColor(imagem, cv2.COLOR_RGB2HSV)
             if metodo == "h":
-                canal_base = imagem_hsv[..., 0]  # Canal H (Matiz)
+                canal_base = imagem_hsv[..., 0]  # Matiz (0-179)
             elif metodo == "s":
-                canal_base = imagem_hsv[..., 1]  # Canal S (Saturação)
-            elif metodo == "v":
-                canal_base = imagem_hsv[..., 2]  # Canal V (Valor/Brilho)
-        
-        # lógica RBG original
-        if metodo == "r":
+                canal_base = imagem_hsv[..., 1]  # Saturação (0-255)
+            else:
+                canal_base = imagem_hsv[..., 2]  # Valor/Brilho (0-255)
+        elif metodo == "r":
             canal_base = imagem[..., 0]
         elif metodo == "g":
             canal_base = imagem[..., 1]


### PR DESCRIPTION
ALTERAÇÕES NO CÓDIGO E O QUE ADICIONEI

1. ATUALIZAÇÃO CABEÇALHO
"""
atualizada a documentação do plugin para incluir suporte aos canais hsv (matiz, saturação e valor/brilho). foram adicionadas explicações sobre a conversão da imagem de rgb para hsv utilizando cv2.cvtcolor(), assim como informações sobre as faixas de valores dos canais hsv e a necessidade de ajuste dinâmico do slider de limiar conforme o canal selecionado.
"""

```
2) Conversão do canal escolhido para tons de cinza (Canal R, Canal G, Canal B, Média RGB ou Canal HSV).

Onde:
* Matiz (H) do espaço HSV.
* Saturação (S) do espaço HSV.
* Valor/Brilho (V) do espaço HSV.

Observações:
* Quando um canal HSV é selecionado, a imagem de entrada é convertida de RBG para HSV utilizando cv.cvtColor().
* No OpenCV, o canal H possui faixa de valores entre 0 e 179, enquanto S e V possuem faixa entre 0 e 255. Portanto, o slider de limiar deve ser ajustado de acordo com o canal selecionado.
```

2. ATUALIZAÇÕES DAS FUNÇÕES 

2.1 def setup_ui(self) -> None:
	"""
	Atualizado a interface adicionando as opções do canal hsv na variável opcoes:

	"""
```	
	opcoes = [
            ("Média RGB", "media"),
            ("Canal Vermelho (R)", "r"),
            ("Canal Verde (G)", "g"),
            ("Canal Azul (B)", "b"),

            # 1º Atualização a interface. Novas Opções do Canal HSV.
            ("Matiz (H)", "h"),
            ("Saturação (S)", "s"),
            ("Valor/Brilho (V)", "v"),
            ]

```
	
2.2 def processar(self, imagem: np.ndarray) -> np.ndarray:
	"""
	Atualizado adicionando uma condicional para a variável metodo que verifica se a seleção de opções foi selecionada a um canal hsv. se sim, ele converte a imagem rbg para hsv usando cv2.cvtcolor().
	"""
```	
	# 2º Verifica se o método selecionado é um canal HSV. Se for, converte a imagem para HSV.

        if metodo in ["h", "s", "v"]:
            imagem_hsv = cv2.cvtColor(imagem, cv2.COLOR_RGB2HSV)
            if metodo == "h":
                canal_base = imagem_hsv[..., 0]  # Matiz (0-179)
            elif metodo == "s":
                canal_base = imagem_hsv[..., 1]  # Saturação (0-255)
            else:
                canal_base = imagem_hsv[..., 2]  # Valor/Brilho (0-255)
        elif metodo == "r":
            canal_base = imagem[..., 0]
        elif metodo == "g":
            canal_base = imagem[..., 1]
        elif metodo == "b":
            canal_base = imagem[..., 2]
        else:
            # Média RGB: calcula a média através do eixo de cor (axis=2)
            # e converte de float de volta para inteiro (uint8)
            canal_base = np.mean(imagem, axis=2).astype(np.uint8)
```	
2.3 def _ao_alterar_parametros(self, marcado: bool) -> None:
	"""
	Nessa função ajustei para que o intervalo do slider seja dinâmico conforme o canal selecionado (H: 0–179; demais: 0–255) e bloqueia sinais temporariamente para evitar disparos recursivos do evento de atualização.
	No caso do canal Matriz 'h', no OpenCV, a Matiz (H) é dividida por 2 (360 / 2 = 180) para compactar o círculo cromático em inteiros de 0 a 179, permitindo seu armazenamento no limite de um canal padrão de 8 bits (0 a 255).
	"""

```
# Bloqueia os sinais para evitar que o evento valueChanged dipare loops indesejados
        self._slider_limiar.blockSignals(True)


        metodo = self._obter_metodo()
        if metodo == "h":
            self._slider_limiar.setRange(0, 179)  # Canal H: 0-179
            if self._slider_limiar.value() > 179:
                self._slider_limiar.setValue(179)  # Ajusta o valor do slider se estiver fora do range
        else:
            self._slider_limiar.setRange(0, 255)  # Aos demais canais: 0-255

        self._slider_limiar.blockSignals(False) 

        # Garante que o teXto eXiba o valor real do slider apos o ajuste do range
        valor_atual = self._slider_limiar.value()
        self._rotulo_limiar.setText(f"Limiar (Threshold): {valor_atual}")    

```   