### PR TITLE
Adiciona detector de cantos FAST

### DIFF
--- a/app.py
+++ b/app.py
@@ -731,6 +731,17 @@ class JanelaPrincipal(QMainWindow):
             aviso = menu_filtros.addAction("(nenhum plugin encontrado)")
             aviso.setEnabled(False)
 
+        # --- Menu Deteccao (pontos e caracteristicas da imagem) ---
+        menu_deteccao = barra.addMenu("Detecção")
+        diretorio_deteccao = os.path.join(
+            _DIRETORIO_RAIZ, "plugins", "deteccao"
+        )
+        carregar_plugins_dinamicamente(menu_deteccao, diretorio_deteccao, self)
+
+        if not _menu_tem_acao_folha(menu_deteccao):
+            aviso = menu_deteccao.addAction("(nenhum plugin encontrado)")
+            aviso.setEnabled(False)
+
         # --- Menu Reconhecimento (leitura e identificação de padrões) ---
         menu_reconhecimento = barra.addMenu("Reconhecimento")
         diretorio_reconhecimento = os.path.join(

--- a/app.py
+++ b/app.py
@@ -731,7 +731,7 @@ class JanelaPrincipal(QMainWindow):
             aviso = menu_filtros.addAction("(nenhum plugin encontrado)")
             aviso.setEnabled(False)
 
-        # --- Menu Deteccao (pontos e caracteristicas da imagem) ---
+        # --- Menu Detecção (pontos e características da imagem) ---
         menu_deteccao = barra.addMenu("Detecção")
         diretorio_deteccao = os.path.join(
             _DIRETORIO_RAIZ, "plugins", "deteccao"

--- a/plugins/deteccao/__init__.py
+++ b/plugins/deteccao/__init__.py
@@ -1,0 +1,1 @@
+"""Plugins de deteccao de caracteristicas em imagens."""

--- a/plugins/deteccao/detector_fast.py
+++ b/plugins/deteccao/detector_fast.py
@@ -1,0 +1,95 @@
+"""Plugin para deteccao de cantos com o algoritmo FAST."""
+
+import numpy as np
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSlider,
+    QVBoxLayout,
+)
+
+from core.plugin_base import PluginBase
+
+
+class DetectorFAST(PluginBase):
+    """Interface do detector de pontos de interesse FAST."""
+
+    display_name = "Detector de Cantos (FAST)"
+
+    def setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        descricao = QLabel(
+            "Detecta cantos comparando cada pixel com os pixels de uma "
+            "circunferência ao seu redor.",
+            self,
+        )
+        descricao.setWordWrap(True)
+        layout.addWidget(descricao)
+
+        self._rotulo_limiar = QLabel("Limiar de intensidade: 20", self)
+        layout.addWidget(self._rotulo_limiar)
+
+        self._slider_limiar = QSlider(Qt.Orientation.Horizontal, self)
+        self._slider_limiar.setRange(1, 255)
+        self._slider_limiar.setValue(20)
+        self._slider_limiar.setToolTip(
+            "Valores menores detectam mais pontos; valores maiores exigem "
+            "cantos com maior contraste."
+        )
+        layout.addWidget(self._slider_limiar)
+
+        self._checkbox_nms = QCheckBox("Supressão de não-maximos", self)
+        self._checkbox_nms.setChecked(True)
+        self._checkbox_nms.setToolTip(
+            "Mantem os pontos mais fortes quando ha varias deteccões próximas."
+        )
+        layout.addWidget(self._checkbox_nms)
+
+        self._rotulo_quantidade = QLabel("Cantos detectados: 0", self)
+        self._rotulo_quantidade.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._rotulo_quantidade)
+
+        layout_botoes = QHBoxLayout()
+
+        self._btn_aplicar = QPushButton("Aplicar", self)
+        self._btn_cancelar = QPushButton("Cancelar", self)
+
+        layout_botoes.addWidget(self._btn_aplicar)
+        layout_botoes.addWidget(self._btn_cancelar)
+
+        layout.addLayout(layout_botoes)
+
+        self._slider_limiar.valueChanged.connect(self._ao_alterar_limiar)
+        self._checkbox_nms.toggled.connect(self._atualizar_preview)
+        self._btn_aplicar.clicked.connect(self._ao_aplicar)
+        self._btn_cancelar.clicked.connect(self.reject)
+
+        self.setMinimumWidth(360)
+
+    def processar(self, imagem: np.ndarray) -> np.ndarray:
+        """Retorna uma copia da imagem original.
+        """
+        return imagem.copy()
+
+    def _ao_alterar_limiar(self, valor: int) -> None:
+        self._rotulo_limiar.setText(f"Limiar de intensidade: {valor}")
+        self._atualizar_preview()
+
+    def _atualizar_preview(self, _marcado: bool | None = None) -> None:
+        if not hasattr(self, "imagem_original") or self.imagem_original is None:
+            return
+
+        imagem_processada = self.processar(self.imagem_original)
+        self.preview_requested.emit(imagem_processada)
+
+    def _ao_aplicar(self) -> None:
+        if not hasattr(self, "imagem_original") or self.imagem_original is None:
+            return
+
+        imagem_processada = self.processar(self.imagem_original)
+        self.apply_requested.emit(imagem_processada)
+        self.accept()

--- a/plugins/deteccao/detector_fast.py
+++ b/plugins/deteccao/detector_fast.py
@@ -1,7 +1,8 @@
-"""Plugin para deteccao de cantos com o algoritmo FAST."""
+"""Plugin para detecção de cantos com o algoritmo FAST."""
 
+import cv2
 import numpy as np
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer, Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QHBoxLayout,
@@ -15,7 +16,7 @@ from core.plugin_base import PluginBase
 
 
 class DetectorFAST(PluginBase):
-    """Interface do detector de pontos de interesse FAST."""
+    """Detecta e marca pontos de interesse FAST na imagem."""
 
     display_name = "Detector de Cantos (FAST)"
 
@@ -42,10 +43,10 @@ class DetectorFAST(PluginBase):
         )
         layout.addWidget(self._slider_limiar)
 
-        self._checkbox_nms = QCheckBox("Supressão de não-maximos", self)
+        self._checkbox_nms = QCheckBox("Supressão de não-máximos", self)
         self._checkbox_nms.setChecked(True)
         self._checkbox_nms.setToolTip(
-            "Mantem os pontos mais fortes quando ha varias deteccões próximas."
+            "Mantém os pontos mais fortes quando há várias detecções próximas."
         )
         layout.addWidget(self._checkbox_nms)
 
@@ -70,10 +71,46 @@ class DetectorFAST(PluginBase):
 
         self.setMinimumWidth(360)
 
+        QTimer.singleShot(0, self._atualizar_preview)
+
+    def _detectar(self, imagem: np.ndarray) -> tuple[np.ndarray, int]:
+        """Retorna uma cópia RGB anotada e a quantidade de cantos detectados."""
+        if imagem.ndim == 3:
+            cinza = cv2.cvtColor(imagem, cv2.COLOR_RGB2GRAY)
+            resultado = imagem.copy()
+        elif imagem.ndim == 2:
+            cinza = imagem
+            resultado = cv2.cvtColor(imagem, cv2.COLOR_GRAY2RGB)
+        else:
+            raise ValueError("A imagem deve possuir um canal ou três canais RGB.")
+
+        detector = cv2.FastFeatureDetector_create(
+            threshold=self._slider_limiar.value(),
+            nonmaxSuppression=self._checkbox_nms.isChecked(),
+            type=cv2.FAST_FEATURE_DETECTOR_TYPE_9_16,
+        )
+
+        pontos = detector.detect(cinza, None)
+
+        imagem_anotada = cv2.drawKeypoints(
+            resultado,
+            pontos,
+            None,
+            color=(255, 0, 0),
+            flags=cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS,
+        )
+
+        return imagem_anotada, len(pontos)
+
     def processar(self, imagem: np.ndarray) -> np.ndarray:
-        """Retorna uma copia da imagem original.
-        """
-        return imagem.copy()
+        """Aplica o FAST e devolve a imagem RGB com os cantos marcados."""
+        resultado, _ = self._detectar(imagem)
+        return resultado
+
+    def _atualizar_quantidade(self) -> np.ndarray:
+        resultado, quantidade = self._detectar(self.imagem_original)
+        self._rotulo_quantidade.setText(f"Cantos detectados: {quantidade}")
+        return resultado
 
     def _ao_alterar_limiar(self, valor: int) -> None:
         self._rotulo_limiar.setText(f"Limiar de intensidade: {valor}")
@@ -83,13 +120,13 @@ class DetectorFAST(PluginBase):
         if not hasattr(self, "imagem_original") or self.imagem_original is None:
             return
 
-        imagem_processada = self.processar(self.imagem_original)
+        imagem_processada = self._atualizar_quantidade()
         self.preview_requested.emit(imagem_processada)
 
     def _ao_aplicar(self) -> None:
         if not hasattr(self, "imagem_original") or self.imagem_original is None:
             return
 
-        imagem_processada = self.processar(self.imagem_original)
+        imagem_processada = self._atualizar_quantidade()
         self.apply_requested.emit(imagem_processada)
         self.accept()

--- a/plugins/deteccao/detector_fast.py
+++ b/plugins/deteccao/detector_fast.py
@@ -1,4 +1,4 @@
-"""Plugin para detecção de cantos com o algoritmo FAST."""
+"""Plugin de detecção de cantos baseado no algoritmo FAST, com suporte a supressão de não-máximos e ajuste dinâmico de limiar."""
 
 import cv2
 import numpy as np
@@ -11,9 +11,7 @@ from PySide6.QtWidgets import (
     QSlider,
     QVBoxLayout,
 )
-
 from core.plugin_base import PluginBase
-
 
 class DetectorFAST(PluginBase):
     """Detecta e marca pontos de interesse FAST na imagem."""


### PR DESCRIPTION
## Descrição

Adiciona um plugin para detecção de cantos utilizando o algoritmo FAST.

## Alterações

- Adiciona o menu de Detecção.
- Implementa o detector FAST.
- Permite ajustar o limiar de intensidade.
- Adiciona opção de supressão de não-máximos.
- Exibe a quantidade de cantos encontrados.
- Marca visualmente os cantos detectados.
- Atualiza a pré-visualização ao abrir e ao alterar os parâmetros.