### PR TITLE
Correção bug de arrasto da janela principal ao mover diálogo de plugin no Linux

### DIFF
--- a/core/plugin_base.py
+++ b/core/plugin_base.py
@@ -10,7 +10,7 @@ Cada plugin deve herdar de ``PluginBase`` e implementar os métodos abstratos
 from abc import abstractmethod
 
 import numpy as np
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import QDialog
 
 
@@ -43,10 +43,21 @@ class PluginBase(QDialog):
         parent : QWidget, opcional
             Widget pai do diálogo.
         """
-        super().__init__(parent)
+        super().__init__(None)
+        self._janela_pai = parent
         self.imagem_original: np.ndarray = imagem.copy()
         self.setWindowTitle(self.display_name)
         self.setup_ui()
+
+        # Centraliza o diálogo sobre a janela pai (reproduz o
+        # comportamento que o Qt faria automaticamente com parent).
+        if parent is not None:
+            geo_pai = parent.geometry()
+            self.adjustSize()
+            x = geo_pai.x() + (geo_pai.width() - self.width()) // 2
+            y = geo_pai.y() + (geo_pai.height() - self.height()) // 2
+            self.move(x, y)
+
 
     @abstractmethod
     def setup_ui(self) -> None:


### PR DESCRIPTION
No linux o Qt traduz essa relação definindo a flag WM_TRANSIENT_FOR via X11, o gerenciador de janelas do Ubuntu interpreta isso como um grupo rígido, fazendo com que a janela pai se mova junto ao arrastar o diálogo

No Windows o sistema lida com essa flag de forma independente, permitindo o movimento seja isolado por padrão

A solução foi desvincular a hierarquia nativa de janelas do Qt passando None no construtor do QDialog fazendo com que o Linux passa a tratar ela como uma janela independente

Como o comportamento do método .exec() gera um laço de eventos modal a nível de aplicação, o bloqueio de cliques na janela pai continua funcionando perfeitamente.

Como efeito colateral, perdemos o posicionamento automático do Qt. Para resolver isso, implementei o cálculo manual de posicionamento no código: capturamos o tamanho da janela principal, subtraímos o tamanho do diálogo e dividimos a diferença por dois, somando à posição inicial da janela pai. Isso garante que os plugins continuem abrindo perfeitamente centralizados sobre a aplicação.

Closes #168 

@gustavoresque 

gostaria de solicitar a badge 🐛 Bug Catcher