### PR TITLE
Algoritmo de huffman

### DIFF
--- a/app.py
+++ b/app.py
@@ -826,6 +826,8 @@ class JanelaPrincipal(QMainWindow):
         if mensagem_status:
             self.statusBar().showMessage(mensagem_status)
 
+        self._sidebar_direita.atualizar_compressao(imagem_bgr)
+
         return novo_documento
 
     def _carregar_imagem_do_caminho(self, caminho: str) -> None:
@@ -1202,6 +1204,9 @@ class JanelaPrincipal(QMainWindow):
 
         self.statusBar().showMessage("Filtro aplicado com sucesso.")
 
+        if self.tabs.currentWidget() == aba:
+            self._sidebar_direita.atualizar_compressao(imagem_bgr)
+
     def _ao_aplicar_multiplas_imagens(self, imagens_rgb, aba_atual):
         """Cria novas abas a partir de múltiplas imagens RGB geradas por um plugin."""
         if not isinstance(aba_atual, DocumentoImagem):
@@ -1253,6 +1258,8 @@ class JanelaPrincipal(QMainWindow):
             )
 
         self.statusBar().showMessage("Desfazer realizado.")
+
+        self._sidebar_direita.atualizar_compressao(estado)
 
     def _restaurar_backup(self) -> None:
         """Restaura a imagem da aba atual ao estado anterior."""
@@ -1375,6 +1382,7 @@ class JanelaPrincipal(QMainWindow):
         if indice == -1: # Nenhuma aba aberta (fechou tudo)
             self._imagem_atual = None
             self._ao_zoom_alterado(1.0)
+            self._sidebar_direita.atualizar_compressao(None)
             return
 
         aba_atual = self.tabs.widget(indice)
@@ -1385,11 +1393,13 @@ class JanelaPrincipal(QMainWindow):
             self._ao_zoom_alterado(zoom_atual)
             if self._ferramenta_ativa_toolbar in {"mover", "zoom"}:
                 self._ao_ferramenta_alterada(self._ferramenta_ativa_toolbar)
+            self._sidebar_direita.atualizar_compressao(aba_atual.imagem_atual)
             return
 
         self._imagem_atual = None
         self._atualizar_visibilidade_laterais(False)
         self._ao_zoom_alterado(1.0)
+        self._sidebar_direita.atualizar_compressao(None)
 
     def keyPressEvent(self, evento) -> None:
         """Atalhos globais."""

--- a/core/compressao_imagem.py
+++ b/core/compressao_imagem.py
@@ -1,0 +1,378 @@
+"""
+core/compressao_imagem.py
+-------------------------
+Módulo de análise de compressão de imagens.
+
+Implementa a codificação de Huffman sobre a matriz de pixels e compara
+o resultado com as compressões JPEG e PNG via OpenCV.
+
+Funcionalidades
+---------------
+* Construção da árvore de Huffman a partir das frequências dos pixels.
+* Cálculo de entropia e redundância dos dados.
+* Compressão simulada via Huffman (tamanho do bitstream).
+* Compressão real via JPEG (``cv2.imencode``) com qualidade configurável.
+* Compressão real via PNG (``cv2.imencode``).
+* Função unificada ``analisar_compressao`` que retorna todos os resultados.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+import struct
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+import cv2
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Árvore de Huffman
+# ---------------------------------------------------------------------------
+
+@dataclass(order=True)
+class NoHuffman:
+    """Nó da árvore de Huffman, comparável por frequência."""
+
+    frequencia: int
+    simbolo: int | None = field(default=None, compare=False)
+    esquerda: "NoHuffman | None" = field(default=None, compare=False)
+    direita: "NoHuffman | None" = field(default=None, compare=False)
+
+
+def construir_arvore_huffman(frequencias: dict[int, int]) -> NoHuffman:
+    """
+    Constrói a árvore de Huffman a partir de um dicionário de frequências.
+
+    Parâmetros
+    ----------
+    frequencias : dict[int, int]
+        Mapeamento símbolo → contagem de ocorrências.
+
+    Retorna
+    -------
+    NoHuffman
+        Raiz da árvore de Huffman.
+    """
+    if not frequencias:
+        return NoHuffman(frequencia=0)
+
+    heap: list[NoHuffman] = [
+        NoHuffman(frequencia=freq, simbolo=simbolo)
+        for simbolo, freq in frequencias.items()
+    ]
+    heapq.heapify(heap)
+
+    # Caso especial: apenas um símbolo distinto.
+    if len(heap) == 1:
+        unico = heapq.heappop(heap)
+        raiz = NoHuffman(
+            frequencia=unico.frequencia,
+            esquerda=unico,
+        )
+        return raiz
+
+    while len(heap) > 1:
+        esquerda = heapq.heappop(heap)
+        direita = heapq.heappop(heap)
+        pai = NoHuffman(
+            frequencia=esquerda.frequencia + direita.frequencia,
+            esquerda=esquerda,
+            direita=direita,
+        )
+        heapq.heappush(heap, pai)
+
+    return heap[0]
+
+
+def gerar_codigos_huffman(raiz: NoHuffman) -> dict[int, str]:
+    """
+    Percorre a árvore e gera o dicionário símbolo → código binário.
+
+    Parâmetros
+    ----------
+    raiz : NoHuffman
+        Raiz da árvore de Huffman.
+
+    Retorna
+    -------
+    dict[int, str]
+        Mapeamento símbolo → string de bits (ex.: ``{0: '00', 128: '1', ...}``).
+    """
+    codigos: dict[int, str] = {}
+
+    def _percorrer(no: NoHuffman | None, prefixo: str) -> None:
+        if no is None:
+            return
+        if no.simbolo is not None:
+            codigos[no.simbolo] = prefixo or "0"
+            return
+        _percorrer(no.esquerda, prefixo + "0")
+        _percorrer(no.direita, prefixo + "1")
+
+    _percorrer(raiz, "")
+    return codigos
+
+
+# ---------------------------------------------------------------------------
+# Métricas de informação
+# ---------------------------------------------------------------------------
+
+def calcular_entropia(frequencias: dict[int, int], total: int) -> float:
+    """
+    Calcula a entropia de Shannon (bits por símbolo).
+
+    H = -Σ p(x) · log₂(p(x))
+    """
+    if total == 0:
+        return 0.0
+
+    entropia = 0.0
+    for freq in frequencias.values():
+        if freq > 0:
+            p = freq / total
+            entropia -= p * math.log2(p)
+    return entropia
+
+
+def calcular_redundancia(entropia: float, bits_por_simbolo: int = 8) -> float:
+    """
+    Calcula a redundância dos dados.
+
+    R = 1 − (H / L)
+
+    Onde *H* é a entropia e *L* são os bits por símbolo no formato original.
+    """
+    if bits_por_simbolo == 0:
+        return 0.0
+    return 1.0 - (entropia / bits_por_simbolo)
+
+
+# ---------------------------------------------------------------------------
+# Compressão Huffman
+# ---------------------------------------------------------------------------
+
+def comprimir_huffman(imagem_bgr: np.ndarray) -> dict[str, Any]:
+    """
+    Aplica a codificação de Huffman sobre os valores de pixel da imagem.
+
+    Parâmetros
+    ----------
+    imagem_bgr : np.ndarray
+        Imagem em formato BGR (OpenCV).
+
+    Retorna
+    -------
+    dict
+        Dicionário com as chaves:
+        - ``tamanho_original``  : int — tamanho bruto em bytes.
+        - ``tamanho_comprimido``: int — tamanho estimado do bitstream em bytes.
+        - ``total_bits``        : int — total de bits do bitstream.
+        - ``entropia``          : float — entropia de Shannon (bits/símbolo).
+        - ``redundancia``       : float — redundância (0–1).
+        - ``taxa_compressao``   : float — razão original / comprimido.
+        - ``economia_percentual``: float — percentual de redução.
+        - ``tabela_codigos``    : dict — primeiros 20 códigos Huffman.
+    """
+    pixels = imagem_bgr.flatten().astype(np.uint8)
+    total_pixels = len(pixels)
+
+    tamanho_original = total_pixels  # cada pixel ocupa 1 byte
+
+    # Contagem de frequências
+    frequencias = dict(Counter(pixels.tolist()))
+
+    # Entropia e redundância
+    entropia = calcular_entropia(frequencias, total_pixels)
+    redundancia = calcular_redundancia(entropia)
+
+    # Árvore e códigos
+    arvore = construir_arvore_huffman(frequencias)
+    codigos = gerar_codigos_huffman(arvore)
+
+    # Tamanho do bitstream comprimido
+    total_bits = sum(
+        frequencias[simbolo] * len(codigo)
+        for simbolo, codigo in codigos.items()
+    )
+    tamanho_comprimido = math.ceil(total_bits / 8)
+
+    # Taxa de compressão
+    taxa = tamanho_original / tamanho_comprimido if tamanho_comprimido > 0 else 0
+    economia = (1 - tamanho_comprimido / tamanho_original) * 100 if tamanho_original > 0 else 0
+
+    # Amostra da tabela de códigos (os 20 mais frequentes)
+    codigos_ordenados = sorted(codigos.items(), key=lambda x: frequencias.get(x[0], 0), reverse=True)
+    tabela_amostra = dict(codigos_ordenados[:20])
+
+    return {
+        "tamanho_original": tamanho_original,
+        "tamanho_comprimido": tamanho_comprimido,
+        "total_bits": total_bits,
+        "entropia": entropia,
+        "redundancia": redundancia,
+        "taxa_compressao": taxa,
+        "economia_percentual": economia,
+        "tabela_codigos": tabela_amostra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Compressão JPEG / PNG (via OpenCV)
+# ---------------------------------------------------------------------------
+
+def comprimir_jpeg(imagem_bgr: np.ndarray, qualidade: int = 95) -> dict[str, Any]:
+    """
+    Codifica a imagem como JPEG e retorna o tamanho resultante.
+
+    Parâmetros
+    ----------
+    imagem_bgr : np.ndarray
+        Imagem em formato BGR.
+    qualidade : int
+        Qualidade JPEG (0–100). Padrão: 95.
+
+    Retorna
+    -------
+    dict
+        Dicionário com ``tamanho_comprimido``, ``economia_percentual`` e
+        ``taxa_compressao``.
+    """
+    tamanho_original = imagem_bgr.nbytes
+
+    parametros = [cv2.IMWRITE_JPEG_QUALITY, qualidade]
+    sucesso, buffer = cv2.imencode(".jpg", imagem_bgr, parametros)
+
+    if not sucesso:
+        return {
+            "tamanho_comprimido": 0,
+            "economia_percentual": 0.0,
+            "taxa_compressao": 0.0,
+        }
+
+    tamanho_comprimido = len(buffer)
+    economia = (1 - tamanho_comprimido / tamanho_original) * 100 if tamanho_original > 0 else 0
+    taxa = tamanho_original / tamanho_comprimido if tamanho_comprimido > 0 else 0
+
+    return {
+        "tamanho_comprimido": tamanho_comprimido,
+        "economia_percentual": economia,
+        "taxa_compressao": taxa,
+    }
+
+
+def comprimir_png(imagem_bgr: np.ndarray) -> dict[str, Any]:
+    """
+    Codifica a imagem como PNG e retorna o tamanho resultante.
+
+    Parâmetros
+    ----------
+    imagem_bgr : np.ndarray
+        Imagem em formato BGR.
+
+    Retorna
+    -------
+    dict
+        Dicionário com ``tamanho_comprimido``, ``economia_percentual`` e
+        ``taxa_compressao``.
+    """
+    tamanho_original = imagem_bgr.nbytes
+
+    sucesso, buffer = cv2.imencode(".png", imagem_bgr)
+
+    if not sucesso:
+        return {
+            "tamanho_comprimido": 0,
+            "economia_percentual": 0.0,
+            "taxa_compressao": 0.0,
+        }
+
+    tamanho_comprimido = len(buffer)
+    economia = (1 - tamanho_comprimido / tamanho_original) * 100 if tamanho_original > 0 else 0
+    taxa = tamanho_original / tamanho_comprimido if tamanho_comprimido > 0 else 0
+
+    return {
+        "tamanho_comprimido": tamanho_comprimido,
+        "economia_percentual": economia,
+        "taxa_compressao": taxa,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Análise unificada
+# ---------------------------------------------------------------------------
+
+def analisar_compressao(imagem_bgr: np.ndarray) -> dict[str, Any]:
+    """
+    Executa todas as análises de compressão e retorna um dicionário consolidado.
+
+    Parâmetros
+    ----------
+    imagem_bgr : np.ndarray
+        Imagem em formato BGR (OpenCV).
+
+    Retorna
+    -------
+    dict
+        Chaves: ``dimensoes``, ``canais``, ``tamanho_original``,
+        ``huffman``, ``jpeg``, ``png``.
+    """
+    altura, largura = imagem_bgr.shape[:2]
+    canais = imagem_bgr.shape[2] if imagem_bgr.ndim == 3 else 1
+    tamanho_original = imagem_bgr.nbytes
+
+    return {
+        "dimensoes": (largura, altura),
+        "canais": canais,
+        "tamanho_original": tamanho_original,
+        "huffman": comprimir_huffman(imagem_bgr),
+        "jpeg": comprimir_jpeg(imagem_bgr),
+        "png": comprimir_png(imagem_bgr),
+    }
+
+
+def salvar_arquivo_huffman(imagem_bgr: np.ndarray, caminho_saida: str) -> None:
+    """
+    Gera e salva o arquivo compactado no formato proprietário .huff.
+    """
+    altura, largura = imagem_bgr.shape[:2]
+    canais = imagem_bgr.shape[2] if imagem_bgr.ndim == 3 else 1
+    
+    pixels = imagem_bgr.flatten().astype(np.uint8)
+    frequencias = dict(Counter(pixels.tolist()))
+    
+    arvore = construir_arvore_huffman(frequencias)
+    codigos = gerar_codigos_huffman(arvore)
+    
+    # Construir bitstream
+    lista_bits = []
+    for p in pixels:
+        lista_bits.append(codigos[p])
+    bitstream_str = "".join(lista_bits)
+    total_bits = len(bitstream_str)
+    
+    # Converter string de bits para bytes
+    buffer_bytes = bytearray()
+    for i in range(0, total_bits, 8):
+        byte_str = bitstream_str[i:i+8]
+        if len(byte_str) < 8:
+            byte_str = byte_str.ljust(8, '0')  # Padding com zeros à direita
+        buffer_bytes.append(int(byte_str, 2))
+        
+    # Salvar em formato binário estruturado
+    with open(caminho_saida, "wb") as f:
+        # Magic header
+        f.write(b"HUFF")
+        # Metadados: largura (I), altura (I), canais (B)
+        f.write(struct.pack(">IIB", largura, altura, canais))
+        # Tabela de frequências: tamanho da tabela (H)
+        f.write(struct.pack(">H", len(frequencias)))
+        for simbolo, freq in frequencias.items():
+            f.write(struct.pack(">BI", simbolo, freq))
+        # Total de bits úteis (Q)
+        f.write(struct.pack(">Q", total_bits))
+        # Dados comprimidos
+        f.write(buffer_bytes)

--- a/layout/BarraFerramentasDireita.py
+++ b/layout/BarraFerramentasDireita.py
@@ -1,24 +1,37 @@
-"""Barra lateral direita com painel de ajustes."""
+"""Barra lateral direita com painel de ajustes e estatísticas de compressão."""
 
 from __future__ import annotations
 
 from pathlib import Path
+import numpy as np
 
 from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
+    QFileDialog,
     QFrame,
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
+    QPushButton,
     QToolButton,
     QVBoxLayout,
     QWidget,
 )
 
 
+def _formatar_tamanho(tamanho_bytes: int) -> str:
+    """Converte bytes para uma string legível (B, KB, MB)."""
+    if tamanho_bytes < 1024:
+        return f"{tamanho_bytes} B"
+    if tamanho_bytes < 1024 * 1024:
+        return f"{tamanho_bytes / 1024:.2f} KB"
+    return f"{tamanho_bytes / (1024 * 1024):.2f} MB"
+
+
 class BarraLateralDireita(QFrame):
-    """Widget da barra lateral direita com painel de ajustes."""
+    """Widget da barra lateral direita com painel de ajustes e comparativo de compressão."""
 
     ajuste_solicitado = Signal(str)
 
@@ -29,6 +42,7 @@ class BarraLateralDireita(QFrame):
         self._largura_expandida = 280
         self._largura_encolhida = 28
         self._esta_encolhida = False
+        self._imagem_atual: np.ndarray | None = None
         self.setFixedWidth(self._largura_expandida)
 
         self._aplicar_estilo()
@@ -116,9 +130,166 @@ class BarraLateralDireita(QFrame):
             grade.addWidget(botao, indice // 5, indice % 5)
 
         container_layout.addLayout(grade)
+
+        # Divisor
+        divisor = QFrame(container)
+        divisor.setFrameShape(QFrame.Shape.HLine)
+        divisor.setObjectName("rightDivisor")
+        container_layout.addWidget(divisor)
+
+        # Seção de Compressão
+        titulo_comp = QLabel("Comparativo de Compressão", container)
+        titulo_comp.setObjectName("rightSectionTitle")
+        container_layout.addWidget(titulo_comp)
+
+        comp_frame = QFrame(container)
+        comp_frame.setObjectName("compressionStatsFrame")
+        comp_grid = QGridLayout(comp_frame)
+        comp_grid.setContentsMargins(10, 10, 10, 10)
+        comp_grid.setVerticalSpacing(8)
+        comp_grid.setHorizontalSpacing(6)
+
+        lbl_orig = QLabel("Original:", comp_frame)
+        lbl_orig.setObjectName("compLabel")
+        self.lbl_orig_val = QLabel("-", comp_frame)
+        self.lbl_orig_val.setObjectName("compVal")
+        self.lbl_orig_val.setAlignment(Qt.AlignmentFlag.AlignRight)
+
+        lbl_huff = QLabel("Huffman:", comp_frame)
+        lbl_huff.setObjectName("compLabel")
+        self.lbl_huff_val = QLabel("-", comp_frame)
+        self.lbl_huff_val.setObjectName("compVal")
+        self.lbl_huff_val.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.lbl_huff_pct = QLabel("-", comp_frame)
+        self.lbl_huff_pct.setObjectName("compPct")
+        self.lbl_huff_pct.setAlignment(Qt.AlignmentFlag.AlignRight)
+
+        lbl_jpeg = QLabel("JPEG:", comp_frame)
+        lbl_jpeg.setObjectName("compLabel")
+        self.lbl_jpeg_val = QLabel("-", comp_frame)
+        self.lbl_jpeg_val.setObjectName("compVal")
+        self.lbl_jpeg_val.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.lbl_jpeg_pct = QLabel("-", comp_frame)
+        self.lbl_jpeg_pct.setObjectName("compPct")
+        self.lbl_jpeg_pct.setAlignment(Qt.AlignmentFlag.AlignRight)
+
+        lbl_png = QLabel("PNG:", comp_frame)
+        lbl_png.setObjectName("compLabel")
+        self.lbl_png_val = QLabel("-", comp_frame)
+        self.lbl_png_val.setObjectName("compVal")
+        self.lbl_png_val.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.lbl_png_pct = QLabel("-", comp_frame)
+        self.lbl_png_pct.setObjectName("compPct")
+        self.lbl_png_pct.setAlignment(Qt.AlignmentFlag.AlignRight)
+
+        lbl_redundancy = QLabel("Redundância:", comp_frame)
+        lbl_redundancy.setObjectName("compLabel")
+        self.lbl_redundancy_val = QLabel("-", comp_frame)
+        self.lbl_redundancy_val.setObjectName("compVal")
+        self.lbl_redundancy_val.setAlignment(Qt.AlignmentFlag.AlignRight)
+
+        comp_grid.addWidget(lbl_orig, 0, 0)
+        comp_grid.addWidget(self.lbl_orig_val, 0, 1, 1, 2)
+
+        comp_grid.addWidget(lbl_huff, 1, 0)
+        comp_grid.addWidget(self.lbl_huff_val, 1, 1)
+        comp_grid.addWidget(self.lbl_huff_pct, 1, 2)
+
+        comp_grid.addWidget(lbl_jpeg, 2, 0)
+        comp_grid.addWidget(self.lbl_jpeg_val, 2, 1)
+        comp_grid.addWidget(self.lbl_jpeg_pct, 2, 2)
+
+        comp_grid.addWidget(lbl_png, 3, 0)
+        comp_grid.addWidget(self.lbl_png_val, 3, 1)
+        comp_grid.addWidget(self.lbl_png_pct, 3, 2)
+
+        comp_grid.addWidget(lbl_redundancy, 4, 0)
+        comp_grid.addWidget(self.lbl_redundancy_val, 4, 1, 1, 2)
+
+        container_layout.addWidget(comp_frame)
+
+        self.btn_exportar = QPushButton("Exportar arquivo compactado (.huff)", container)
+        self.btn_exportar.setObjectName("huffExportButton")
+        self.btn_exportar.setEnabled(False)
+        self.btn_exportar.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_exportar.clicked.connect(self._exportar_huffman)
+        container_layout.addWidget(self.btn_exportar)
+
         container_layout.addStretch()
 
         return container
+
+    def atualizar_compressao(self, imagem_bgr: np.ndarray | None) -> None:
+        """Calcula e atualiza as estatísticas de compressão da imagem atual."""
+        self._imagem_atual = imagem_bgr
+        if imagem_bgr is None:
+            self.lbl_orig_val.setText("-")
+            self.lbl_huff_val.setText("-")
+            self.lbl_huff_pct.setText("-")
+            self.lbl_jpeg_val.setText("-")
+            self.lbl_jpeg_pct.setText("-")
+            self.lbl_png_val.setText("-")
+            self.lbl_png_pct.setText("-")
+            self.lbl_redundancy_val.setText("-")
+            self.btn_exportar.setEnabled(False)
+            return
+
+        try:
+            from core.compressao_imagem import analisar_compressao
+
+            res = analisar_compressao(imagem_bgr)
+            tamanho_orig = res["tamanho_original"]
+
+            self.lbl_orig_val.setText(_formatar_tamanho(tamanho_orig))
+
+            # Huffman
+            huff = res["huffman"]
+            self.lbl_huff_val.setText(_formatar_tamanho(huff["tamanho_comprimido"]))
+            self.lbl_huff_pct.setText(f"-{huff['economia_percentual']:.1f}%")
+            self.lbl_redundancy_val.setText(f"{huff['redundancia'] * 100:.2f}%")
+
+            # JPEG
+            jpeg = res["jpeg"]
+            self.lbl_jpeg_val.setText(_formatar_tamanho(jpeg["tamanho_comprimido"]))
+            self.lbl_jpeg_pct.setText(f"-{jpeg['economia_percentual']:.1f}%")
+
+            # PNG
+            png = res["png"]
+            self.lbl_png_val.setText(_formatar_tamanho(png["tamanho_comprimido"]))
+            self.lbl_png_pct.setText(f"-{png['economia_percentual']:.1f}%")
+
+            self.btn_exportar.setEnabled(True)
+        except Exception as e:
+            print(f"[Erro de análise de compressão] {e}")
+            self.lbl_orig_val.setText("erro")
+
+    def _exportar_huffman(self) -> None:
+        if self._imagem_atual is None:
+            return
+
+        caminho, _ = QFileDialog.getSaveFileName(
+            self,
+            "Salvar arquivo compactado",
+            "",
+            "Arquivo Huffman (*.huff)"
+        )
+        if not caminho:
+            return
+
+        try:
+            from core.compressao_imagem import salvar_arquivo_huffman
+            salvar_arquivo_huffman(self._imagem_atual, caminho)
+            QMessageBox.information(
+                self,
+                "Sucesso",
+                f"Arquivo compactado com sucesso!\nSalvo em: {caminho}"
+            )
+        except Exception as e:
+            QMessageBox.critical(
+                self,
+                "Erro",
+                f"Erro ao salvar arquivo compactado:\n{e}"
+            )
 
     def _icone_svg_arquivo(self, nome_arquivo: str) -> QIcon:
         caminho_icone = Path(__file__).parent / "ui" / "icons" / nome_arquivo

--- a/layout/styles/right_sidebar.qss
+++ b/layout/styles/right_sidebar.qss
@@ -96,3 +96,57 @@ QToolButton#layerControlButton {
 QToolButton#layerControlButton:hover {
     background-color: #3c3c3c;
 }
+
+QFrame#rightDivisor {
+    color: #333333;
+    max-height: 1px;
+    margin-top: 12px;
+    margin-bottom: 12px;
+}
+
+QFrame#compressionStatsFrame {
+    background-color: #252525;
+    border: 1px solid #333333;
+    border-radius: 6px;
+    padding: 2px;
+}
+
+QLabel#compLabel {
+    color: #9ca3af;
+    font-size: 11px;
+    font-weight: 500;
+}
+
+QLabel#compVal {
+    color: #f3f4f6;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+QLabel#compPct {
+    color: #10b981;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+QPushButton#huffExportButton {
+    background-color: #2a2a2a;
+    color: #d1d5db;
+    border: 1px solid #3c3c3c;
+    border-radius: 4px;
+    padding: 6px;
+    font-size: 10px;
+    font-weight: 600;
+    margin-top: 4px;
+}
+
+QPushButton#huffExportButton:hover {
+    background-color: #3c3c3c;
+    color: #ffffff;
+}
+
+QPushButton#huffExportButton:disabled {
+    background-color: #1a1a1a;
+    color: #555555;
+    border: 1px solid #252525;
+}

--- a/layout/ui/icons/compressao.svg
+++ b/layout/ui/icons/compressao.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="4 14 8 10 4 6"/>
+  <polyline points="20 14 16 10 20 6"/>
+  <line x1="9" y1="10" x2="15" y2="10"/>
+</svg>


### PR DESCRIPTION
Implementei um sistema de análise e comparativo de compressão de imagens integrado de forma permanente na barra lateral direita do aplicativo, que se atualiza automaticamente a cada alteração na imagem ativa.

Para a compressão Huffman, o código mapeia a frequência de todos os valores de pixels da imagem para construir uma árvore binária de busca otimizada. Os pixels mais comuns recebem códigos de bits mais curtos e os menos comuns recebem códigos mais longos. A partir disso, o sistema calcula a entropia de Shannon (limite de informação por pixel), a redundância de dados contida na matriz original e estima o tamanho do fluxo compactado final. Também foi criada uma função que exporta e gera um arquivo binário estruturado com a extensão .huff, contendo os metadados da imagem, a tabela de frequências e os bits comprimidos.

Para fins de comparação, a ferramenta codifica dinamicamente a imagem usando os formatos JPEG (com perda de dados) e PNG (sem perda de dados) via OpenCV. O painel exibe e contrasta os tamanhos finais gerados por cada método (Original, Huffman, JPEG e PNG), junto com as taxas de economia de espaço calculadas em tempo real.

gostaria de solicitar as badges ⭐ Código de Ouro, 🧠 Lógica Brilhante e 💻 Enter the Matrix

Closes #151 

@gustavoresque 